### PR TITLE
Show appropriate title when someone joins a private conversation

### DIFF
--- a/dnas/relay/zomes/integrity/relay/src/lib.rs
+++ b/dnas/relay/zomes/integrity/relay/src/lib.rs
@@ -54,7 +54,7 @@ pub enum Privacy {
 
 #[derive(Serialize, Deserialize, Debug, SerializedBytes, Clone)]
 pub struct Properties {
-    pub name: String,
+    pub created: Timestamp,
     pub privacy: Privacy,
     pub progenitor: AgentPubKey,
 }

--- a/ui/src/lib/ConversationSummary.svelte
+++ b/ui/src/lib/ConversationSummary.svelte
@@ -243,6 +243,6 @@
 
 <style>
   .unread {
-    font-weight: bold;
+    font-weight: 550;
   }
 </style>

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -250,6 +250,8 @@
       <a class='pl-5' href={`/conversations/${conversation.data.id}/${conversation.data.privacy === Privacy.Public ? 'details' : 'invite'}`}>
         <SvgIcon icon='addPerson' size='24' color={$modeCurrent ? '%232e2e2e' : 'white'} />
       </a>
+    {:else}
+      <span class='pl-8'>&nbsp;</span>
     {/if}
   {/if}
 </Header>
@@ -326,7 +328,7 @@
                 <strong class='ml-2 text-sm'>{$t('conversations.share_invite_code')}</strong>
             </Button>
             {/if}
-  
+
           {/if}
         </div>
       {:else}

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -9,7 +9,7 @@
   import { t } from '$lib/translations';
   import { copyToClipboard, handleFileChange, isMobile, MIN_TITLE_LENGTH, shareText } from '$lib/utils';
   import type { RelayStore } from '$store/RelayStore';
-  import { Privacy, type Config, type Invitation } from '../../../../types';
+  import { Privacy, type Config } from '../../../../types';
   import Button from '$lib/Button.svelte';
 
   // Silly hack to get around issues with typescript in sveltekit-i18n

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -52,7 +52,6 @@ export enum Privacy {
 // DNA modifier properties for a conversation
 export interface Properties {
   created: number,
-  name: string;
   privacy: Privacy;
   progenitor: AgentPubKeyB64;
 }


### PR DESCRIPTION
For 1:1 conversation it should be the name of the conversation creator. For group conversations it should be name of creator + # of people invited.

TODO: right now we only show the # of people invited until the conversation syncs, then it shows the profiles of the actual joined members. This could be confusing at the beginning when its only you and the creator. Would be ncie to store the # of people invited in the conversation cell from the beginning.

This is a breaking change because we removed name from conversation Properties