### PR TITLE
build: bump tauri deps, remove patched version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,7 +4195,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.11",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -9116,8 +9116,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "2.0.2"
-source = "git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b#4a2d51a73adc2005701e801c0b7a41ca2e135f8b"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd96d46534b10765ce0c6208f9451d98ea38636364a41b272d3610c70dd0e4c3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9151,7 +9152,7 @@ dependencies = [
  "tauri-macros",
  "tauri-runtime",
  "tauri-runtime-wry",
- "tauri-utils 2.0.1 (git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b)",
+ "tauri-utils",
  "thiserror",
  "tokio",
  "tray-icon",
@@ -9166,7 +9167,8 @@ dependencies = [
 [[package]]
 name = "tauri-build"
 version = "2.0.1"
-source = "git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b#4a2d51a73adc2005701e801c0b7a41ca2e135f8b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935f9b3c49b22b3e2e485a57f46d61cd1ae07b1cbb2ba87387a387caf2d8c4e7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -9178,7 +9180,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "tauri-utils 2.0.1 (git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b)",
+ "tauri-utils",
  "tauri-winres",
  "toml 0.8.19",
  "walkdir",
@@ -9187,7 +9189,8 @@ dependencies = [
 [[package]]
 name = "tauri-codegen"
 version = "2.0.1"
-source = "git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b#4a2d51a73adc2005701e801c0b7a41ca2e135f8b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95d7443dd4f0b597704b6a14b964ee2ed16e99928d8e6292ae9825f09fbcd30e"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -9202,7 +9205,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "syn 2.0.79",
- "tauri-utils 2.0.1 (git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b)",
+ "tauri-utils",
  "thiserror",
  "time",
  "url",
@@ -9213,14 +9216,15 @@ dependencies = [
 [[package]]
 name = "tauri-macros"
 version = "2.0.1"
-source = "git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b#4a2d51a73adc2005701e801c0b7a41ca2e135f8b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2c0963ccfc3f5194415f2cce7acc975942a8797fbabfb0aa1ed6f59326ae7f"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
  "tauri-codegen",
- "tauri-utils 2.0.1 (git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b)",
+ "tauri-utils",
 ]
 
 [[package]]
@@ -9235,7 +9239,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "tauri-utils 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tauri-utils",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -9384,8 +9388,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.0.1"
-source = "git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b#4a2d51a73adc2005701e801c0b7a41ca2e135f8b"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8f437293d6f5e5dce829250f4dbdce4e0b52905e297a6689cc2963eb53ac728"
 dependencies = [
  "dpi",
  "gtk",
@@ -9394,7 +9399,7 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "serde_json",
- "tauri-utils 2.0.1 (git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b)",
+ "tauri-utils",
  "thiserror",
  "url",
  "windows 0.58.0",
@@ -9402,8 +9407,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.0.1"
-source = "git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b#4a2d51a73adc2005701e801c0b7a41ca2e135f8b"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaac63b65df8e85570993eaf93ae1dd73a6fb66d8bd99674ce65f41dc3c63e7d"
 dependencies = [
  "gtk",
  "http 1.1.0",
@@ -9417,7 +9423,7 @@ dependencies = [
  "softbuffer",
  "tao",
  "tauri-runtime",
- "tauri-utils 2.0.1 (git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b)",
+ "tauri-utils",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -9430,39 +9436,6 @@ name = "tauri-utils"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c38b0230d6880cf6dd07b6d7dd7789a0869f98ac12146e0d18d1c1049215a045"
-dependencies = [
- "cargo_metadata 0.18.1",
- "ctor",
- "dunce",
- "glob",
- "html5ever",
- "infer",
- "json-patch",
- "kuchikiki",
- "log",
- "memchr",
- "phf 0.11.2",
- "proc-macro2",
- "quote",
- "regex",
- "schemars",
- "semver 1.0.23",
- "serde",
- "serde-untagged",
- "serde_json",
- "serde_with",
- "swift-rs",
- "thiserror",
- "toml 0.8.19",
- "url",
- "urlpattern",
- "uuid 1.10.0",
-]
-
-[[package]]
-name = "tauri-utils"
-version = "2.0.1"
-source = "git+https://github.com/tauri-apps/tauri.git?rev=4a2d51a73adc2005701e801c0b7a41ca2e135f8b#4a2d51a73adc2005701e801c0b7a41ca2e135f8b"
 dependencies = [
  "brotli",
  "cargo_metadata 0.18.1",
@@ -11151,7 +11124,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,3 @@ path = "dnas/relay/zomes/integrity/relay"
 edition = "2021"
 rust-version = "1.74.0"
 version = "0.5.0-beta"
-
-
-[patch.crates-io]
-# Patch tauri with unreleased fix for https://github.com/tauri-apps/tauri/issues/11171
-tauri = { git = "https://github.com/tauri-apps/tauri.git", rev = "4a2d51a73adc2005701e801c0b7a41ca2e135f8b" }
-tauri-build = { git = "https://github.com/tauri-apps/tauri.git", rev = "4a2d51a73adc2005701e801c0b7a41ca2e135f8b" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@holochain-playground/cli": "^0.2.0",
         "@holochain/hc-spin": "^0.400.0-dev.3",
         "@rollup/plugin-typescript": "^8.0.0",
-        "@tauri-apps/cli": "^2.0.2",
+        "@tauri-apps/cli": "^2.0.3",
         "@tsconfig/svelte": "^5.0.4",
         "@types/dompurify": "^3.0.5",
         "@types/lodash-es": "^4.17.12",
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.0.2.tgz",
-      "integrity": "sha512-R4ontHZvXORArERAHIidp5zRfZEshZczTiK+poslBv7AGKpQZoMw+E49zns7mOmP64i2Cq9Ci0pJvi4Rm8Okzw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.0.3.tgz",
+      "integrity": "sha512-JwEyhc5BAVpn4E8kxzY/h7+bVOiXQdudR1r3ODMfyyumZBfgIWqpD/WuTcPq6Yjchju1BSS+80jAE/oYwI/RKg==",
       "dev": true,
       "bin": {
         "tauri": "tauri.js"
@@ -2059,22 +2059,22 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.0.2",
-        "@tauri-apps/cli-darwin-x64": "2.0.2",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.0.2",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.0.2",
-        "@tauri-apps/cli-linux-arm64-musl": "2.0.2",
-        "@tauri-apps/cli-linux-x64-gnu": "2.0.2",
-        "@tauri-apps/cli-linux-x64-musl": "2.0.2",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.0.2",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.0.2",
-        "@tauri-apps/cli-win32-x64-msvc": "2.0.2"
+        "@tauri-apps/cli-darwin-arm64": "2.0.3",
+        "@tauri-apps/cli-darwin-x64": "2.0.3",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.0.3",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.0.3",
+        "@tauri-apps/cli-linux-arm64-musl": "2.0.3",
+        "@tauri-apps/cli-linux-x64-gnu": "2.0.3",
+        "@tauri-apps/cli-linux-x64-musl": "2.0.3",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.0.3",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.0.3",
+        "@tauri-apps/cli-win32-x64-msvc": "2.0.3"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.0.2.tgz",
-      "integrity": "sha512-B+/a8Q6wAqmB4A4HVeK0oQP5TdQGKW60ZLOI9O2ktH2HPr9ETr3XkwXPuJ2uAOuGEgtRZHBgFOIgG000vMnKlg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.0.3.tgz",
+      "integrity": "sha512-jIsbxGWS+As1ZN7umo90nkql/ZAbrDK0GBT6UsgHSz5zSwwArICsZFFwE1pLZip5yoiV5mn3TGG2c1+v+0puzQ==",
       "cpu": [
         "arm64"
       ],
@@ -2088,9 +2088,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.0.2.tgz",
-      "integrity": "sha512-kaurhn6XT4gAVCPAQSSHl/CHFxTS0ljc47N7iGTSlYJ03sCWPRZeNuVa/bn6rolz9MA2JfnRnFqB1pUL6jzp9Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.0.3.tgz",
+      "integrity": "sha512-ROITHtLTA1muyrwgyuwyasmaLCGtT4as/Kd1kerXaSDtFcYrnxiM984ZD0+FDUEDl5BgXtYa/sKKkKQFjgmM0A==",
       "cpu": [
         "x64"
       ],
@@ -2104,9 +2104,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.0.2.tgz",
-      "integrity": "sha512-bVrofjlacMxmGMcqK18iBW05tsZXOd19/MnqruFFcHSVjvkGGIXHMtUbMXnZNXBPkHDsnfytNtkY9SZGfCFaBA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.0.3.tgz",
+      "integrity": "sha512-bQ3EZwCFfrLg/ZQ2I8sLuifSxESz4TP56SleTkKsPtTIZgNnKpM88PRDz4neiRroHVOq8NK0X276qi9LjGcXPw==",
       "cpu": [
         "arm"
       ],
@@ -2120,9 +2120,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.0.2.tgz",
-      "integrity": "sha512-7XCBn0TTBVQGnV42dXcbHPLg/9W8kJoVzuliIozvNGyRWxfXqDbQYzpI48HUQG3LgHMabcw8+pVZAfGhevLrCA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.0.3.tgz",
+      "integrity": "sha512-aLfAA8P9OTErVUk3sATxtXqpAtlfDPMPp4fGjDysEELG/MyekGhmh2k/kG/i32OdPeCfO+Nr37wJksARJKubGw==",
       "cpu": [
         "arm64"
       ],
@@ -2136,9 +2136,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.2.tgz",
-      "integrity": "sha512-1xi2SreGVlpAL68MCsDUY63rdItUdPZreXIAcOVqvUehcJRYOa1XGSBhrV0YXRgZeh0AtKC19z6PRzcv4rosZA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.3.tgz",
+      "integrity": "sha512-I4MVD7nf6lLLRmNQPpe5beEIFM6q7Zkmh77ROA5BNu/+vHNL5kiTMD+bmd10ZL2r753A6pO7AvqkIxcBuIl0tg==",
       "cpu": [
         "arm64"
       ],
@@ -2152,9 +2152,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.0.2.tgz",
-      "integrity": "sha512-WVjwYzPWFqZVg1fx6KSU5w47Q0VbMyaCp34qs5EcS8EIU0/RnofdzqUoOYqvgGVgNgoz7Pj5dXK2SkS8BHXMmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.0.3.tgz",
+      "integrity": "sha512-C6Jkx2zZGKkoi+sg5FK9GoH/0EvAaOgrZfF5azV5EALGba46g7VpWcZgp9zFUd7K2IzTi+0OOY8TQ2OVfKZgew==",
       "cpu": [
         "x64"
       ],
@@ -2168,9 +2168,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.2.tgz",
-      "integrity": "sha512-h5miE2mctgaQNn/BbG9o1pnJcrx+VGBi2A6JFqGu934lFgSV5+s28M8Gc8AF2JgFH4hQV4IuMkeSw8Chu5Dodg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.3.tgz",
+      "integrity": "sha512-qi4ghmTfSAl+EEUDwmwI9AJUiOLNSmU1RgiGgcPRE+7A/W+Am9UnxYySAiRbB/gJgTl9sj/pqH5Y9duP1/sqHg==",
       "cpu": [
         "x64"
       ],
@@ -2184,9 +2184,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.0.2.tgz",
-      "integrity": "sha512-2b8oO0+dYonahG5PfA/zoq0zlafLclfmXgqoWDZ++UiPtQHJNpNeEQ8GWbSFKGHQ494Jo6jHvazOojGRE1kqAg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.0.3.tgz",
+      "integrity": "sha512-UXxHkYmFesC97qVmZre4vY7oDxRDtC2OeKNv0bH+iSnuUp/ROxzJYGyaelnv9Ybvgl4YVqDCnxgB28qMM938TA==",
       "cpu": [
         "arm64"
       ],
@@ -2200,9 +2200,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.0.2.tgz",
-      "integrity": "sha512-axgICLunFi0To3EibdCBgbST5RocsSmtM4c04+CbcX8WQQosJ9ziWlCSrrOTRr+gJERAMSvEyVUS98f6bWMw9A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.0.3.tgz",
+      "integrity": "sha512-D+xoaa35RGlkXDpnL5uDTpj29untuC5Wp6bN9snfgFDagD0wnFfC8+2ZQGu16bD0IteWqDI0OSoIXhNvy+F+wg==",
       "cpu": [
         "ia32"
       ],
@@ -2216,9 +2216,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.0.2.tgz",
-      "integrity": "sha512-JR17cM6+DyExZRgpXr2/DdqvcFYi/EKvQt8dI5R1/uQoesWd8jeNnrU7c1FG1Zmw9+pTzDztsNqEKsrNq2sNIg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.0.3.tgz",
+      "integrity": "sha512-eWV9XWb4dSYHXl13OtYWLjX1JHphUEkHkkGwJrhr8qFBm7RbxXxQvrsUEprSi51ug/dwJenjJgM4zR8By4htfw==",
       "cpu": [
         "x64"
       ],
@@ -8707,7 +8707,7 @@
         "@sveltejs/kit": "^2.5.18",
         "@sveltejs/vite-plugin-svelte": "^3.1.1",
         "@tailwindcss/forms": "^0.5.7",
-        "@tauri-apps/cli": "^2.0.2",
+        "@tauri-apps/cli": "^2.0.3",
         "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
         "@tauri-apps/plugin-notification": "^2.0.0",
         "@types/node": "^20.11.19",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@holochain-playground/cli": "^0.2.0",
     "@holochain/hc-spin": "^0.400.0-dev.3",
     "@rollup/plugin-typescript": "^8.0.0",
-    "@tauri-apps/cli": "^2.0.2",
+    "@tauri-apps/cli": "^2.0.3",
     "@tsconfig/svelte": "^5.0.4",
     "@types/dompurify": "^3.0.5",
     "@types/lodash-es": "^4.17.12",

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     "@sveltejs/kit": "^2.5.18",
     "@sveltejs/vite-plugin-svelte": "^3.1.1",
     "@tailwindcss/forms": "^0.5.7",
-    "@tauri-apps/cli": "^2.0.2",
+    "@tauri-apps/cli": "^2.0.3",
     "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-notification": "^2.0.0",
     "@types/node": "^20.11.19",


### PR DESCRIPTION
Patched tauri no longer needed as required bug fix has been released.