### PR TITLE
fix(ui): 5m timeout for initial zome call

### DIFF
--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -61,8 +61,8 @@
 					fn_name: "ping",
 				} as RoleNameCallZomeRequest, 
 
-				// 48s timeout
-				48 * 1000
+				// 5m timeout
+				5 * 60 * 1000
 			);
 			console.log("Relay cell ready.");
 


### PR DESCRIPTION
I had accidentally reduced the first zome call timeout from 240s to 48s. 

Set to 5 mins -- feels like more than enough margin.