### PR TITLE
Fix/blank screen ubuntu 22

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,9 +30,9 @@ pub fn run() {
     // that is included in ubuntu 22.04.
     #[cfg(all(mobile, target_os = "linux"))]
     {
-		std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-	}
+    }
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,15 +25,6 @@ pub fn happ_bundle() -> anyhow::Result<AppBundle> {
 #[allow(unused_mut)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Workaround for linux webkit issues where screen is blank.
-    // They seem to only arise on the version of webkitgtk
-    // that is included in ubuntu 22.04.
-    #[cfg(all(mobile, target_os = "linux"))]
-    {
-        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-    }
-
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,15 @@ pub fn happ_bundle() -> anyhow::Result<AppBundle> {
 #[allow(unused_mut)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Workaround for linux webkit issues where screen is blank.
+    // They seem to only arise on the version of webkitgtk
+    // that is included in ubuntu 22.04.
+    #[cfg(all(mobile, target_os = "linux"))]
+    {
+		std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+	}
+
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,21 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Workaround for linux webkit issues where screen is blank.
+    // They seem to only arise on the version of webkitgtk
+    // that is included in ubuntu 22.04.
+    #[cfg(all(mobile, target_os = "linux"))]
+    {
+        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     tauri_app_lib::run();
+
+    // Remove workaround env vars
+    #[cfg(all(mobile, target_os = "linux"))]
+    {
+        std::env::remove_var("WEBKIT_DISABLE_COMPOSITING_MODE");
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER");
+    }
 }


### PR DESCRIPTION
Some users reported a blank screen on ubuntu 22.04.

I believe this is the webkitgtk compositing issue. See https://github.com/tauri-apps/tauri/issues/5143