### PR TITLE
More ci fixes

### DIFF
--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   create-release:
     permissions: write-all
+    environment: Relay Release
     runs-on: ubuntu-latest
     outputs:
       releaseId: ${{ steps.step1.outputs.id }}
@@ -24,6 +25,7 @@ jobs:
   release-tauri-app-linux:
     needs: create-release
     permissions: write-all
+    environment: Relay Release
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -72,10 +74,10 @@ jobs:
 
   release-tauri-app-android:
     permissions: write-all
+    environment: Relay Release
     needs: 
       - release-tauri-app-linux
       - create-release
-    environment: Relay Release
     runs-on: 'ubuntu-22.04' 
     steps:
       - uses: actions/checkout@v3
@@ -127,6 +129,7 @@ jobs:
   release-tauri-app-windows:
     needs: create-release
     permissions: write-all
+    environment: Relay Release
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -163,10 +166,16 @@ jobs:
         run: |
 
           # Powershell settings to make the script exit on error
-          $ErrorActionPreference = "Stop"
-          Set-StrictMode -Version Latest
-          $PSNativeCommandUseErrorActionPreference = $true
-
+          # If the github env variable IGNORE_WINDOWS_CODESIGNING_ERROR is "true",
+          # then any errors in this script will not be fatal to the job.
+          $IGNORE_WINDOWS_CODESIGNING_ERROR = "${{ vars.IGNORE_WINDOWS_CODESIGNING_ERROR }}"
+          if ( "true" -ne $IGNORE_WINDOWS_CODESIGNING_ERROR )
+          {
+            $ErrorActionPreference = "Stop"
+            Set-StrictMode -Version Latest
+            $PSNativeCommandUseErrorActionPreference = $true
+          }
+          
           # read name and version from tauri.conf.json
           $TAURI_CONF = (Get-Content src-tauri\tauri.conf.json | Out-String | ConvertFrom-Json)
           $APP_PRODUCT_NAME_VERSION = "$($TAURI_CONF.productName)_$($TAURI_CONF.version)"
@@ -201,6 +210,7 @@ jobs:
   release-tauri-app-macos:
     needs: create-release
     permissions: write-all
+    environment: Relay Release
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -75,7 +75,7 @@ jobs:
     needs: 
       - release-tauri-app-linux
       - create-release
-
+    environment: Relay Release
     runs-on: 'ubuntu-22.04' 
     steps:
       - uses: actions/checkout@v3
@@ -108,9 +108,9 @@ jobs:
       - name: setup Android signing
         run: |
           cd src-tauri/gen/android
+          base64 -d <<< "${{ secrets.ANDROID_KEY_BASE64 }}" > $RUNNER_TEMP/keystore.jks
           echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" > keystore.properties
           echo "keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
-          base64 -d <<< "${{ secrets.ANDROID_KEY_BASE64 }}" > $RUNNER_TEMP/keystore.jks
           echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
           echo "storePassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.7.1] - 2024-11-04
+## [0.7.1] - 2024-11-12
 
 ### Added
 - Automated release builds in CI
-
+- Windows bundle code signing, macOS bundle code signing and notarization in CI
+- Added a github env var IGNORE_WINDOWS_CODESIGNING_ERROR. When set to "true", errors with windows code signing will not be fatal to the build job.
+- All releases except the Android app use a different icon with the Volla logo.
+- Fix: Blank screen on Ubuntu 22.04
 
 ## [0.7.0-beta] - 2024-10-23
 


### PR DESCRIPTION
- all jobs specify 'Relay Release' environment to access environment-specific secrets
- Set github env var `IGNORE_WINDOWS_CODESIGNING_ERROR` to "true" to ignore windows codesigning errors and publish bundles anyway