### PR TITLE
Fix/numbers treated as links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5982,6 +5982,20 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/linkify-string": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-string/-/linkify-string-4.2.0.tgz",
+      "integrity": "sha512-LqOKk0+RlqibFkxjPAGOL7Mfssqj6/SdG9QWGvzeVDpoWXhaw9OXxseCtFanjIl7C6UyTTZizhyGr4IWLfijiw==",
+      "peerDependencies": {
+        "linkifyjs": "^4.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.2.0.tgz",
+      "integrity": "sha512-pCj3PrQyATaoTYKHrgWRF3SJwsm61udVh+vuls/Rl6SptiDhgE7ziUIudAedRY9QEfynmM7/RmLEfPUyw1HPCw==",
+      "peer": true
+    },
     "node_modules/lit": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
@@ -9232,6 +9246,7 @@
         "@tauri-apps/plugin-shell": "^2.0.1",
         "bigger-picture": "^1.1.17",
         "dompurify": "^3.1.7",
+        "linkify-string": "^4.2.0",
         "lodash-es": "^4.17.21",
         "p-retry": "^6.2.0",
         "svelte-french-toast": "^1.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,6 +25,7 @@
     "@tauri-apps/plugin-shell": "^2.0.1",
     "bigger-picture": "^1.1.17",
     "dompurify": "^3.1.7",
+    "linkify-string": "^4.2.0",
     "lodash-es": "^4.17.21",
     "p-retry": "^6.2.0",
     "svelte-french-toast": "^1.2.0",

--- a/ui/src/lib/ConversationSummary.svelte
+++ b/ui/src/lib/ConversationSummary.svelte
@@ -10,6 +10,7 @@
   import { isMobile, sanitizeHTML } from "$lib/utils";
   import type { ConversationStore } from "$store/ConversationStore";
   import { Privacy } from "../types";
+  import { goto } from "$app/navigation";
 
   export let store: ConversationStore;
   $: conversation = store.conversation;
@@ -103,6 +104,8 @@
     if (isDragging) {
       e.preventDefault();
       e.stopPropagation();
+    } else {
+      goto(`/conversations/${$conversation.id}`);
     }
   }
 
@@ -142,9 +145,8 @@
     transition:slide={{ axis: "x", duration: 300, easing: quintOut }}
     on:outroend={archiveConversation}
   >
-    <a
-      href="/conversations/{$conversation.id}"
-      class={`z-10 flex w-full min-w-0 flex-row items-center rounded-lg bg-surface-100 px-2 py-3 transition-transform duration-300 ease-in-out hover:bg-tertiary-400 dark:bg-surface-900 dark:hover:bg-secondary-500 ${isHovering && "bg-tertiary-400 dark:!bg-secondary-500"}`}
+    <button
+      class={`bg-surface-100 hover:bg-tertiary-400 dark:bg-surface-900 dark:hover:bg-secondary-500 z-10 flex w-full min-w-0 flex-row items-center rounded-lg px-2 py-3 text-left transition-transform duration-300 ease-in-out ${isHovering && "bg-tertiary-400 dark:!bg-secondary-500"}`}
       style="transform: translateX({-$x}px)"
       use:pan={{ delay: 10 }}
       on:pan={handlePan}
@@ -162,7 +164,7 @@
           {#if allMembers.length == 0}
             <!-- When you join a private conversation and it has not synced yet -->
             <span
-              class="flex h-10 w-10 items-center justify-center rounded-full bg-secondary-300 dark:bg-secondary-400"
+              class="bg-secondary-300 dark:bg-secondary-400 flex h-10 w-10 items-center justify-center rounded-full"
             >
               <SvgIcon icon="group" size="20" color="#ccc" />
             </span>
@@ -213,7 +215,7 @@
         />
       {:else}
         <span
-          class="flex h-10 w-10 items-center justify-center rounded-full bg-secondary-300 dark:bg-secondary-400"
+          class="bg-secondary-300 dark:bg-secondary-400 flex h-10 w-10 items-center justify-center rounded-full"
         >
           <SvgIcon icon="group" size="20" color="#ccc" />
         </span>
@@ -222,7 +224,7 @@
         <span class="text-base">{store.title}</span>
         <span class="flex min-w-0 items-center overflow-hidden text-ellipsis text-nowrap text-xs">
           {#if unread}
-            <span class="mr-2 inline-block h-2 w-2 rounded-full bg-primary-500"></span>
+            <span class="bg-primary-500 mr-2 inline-block h-2 w-2 rounded-full"></span>
           {/if}
           {#if $conversation.privacy === Privacy.Private && joinedMembers.length === 0 && allMembers.length === 1}
             <span class="text-secondary-400">{$t("conversations.unconfirmed")}</span>
@@ -230,14 +232,14 @@
             {lastMessageAuthor || ""}:&nbsp;
             {@html sanitizeHTML($lastMessage.content || "")}
             {#if $lastMessage.images.length > 0}
-              &nbsp;<span class="italic text-secondary-400"
+              &nbsp;<span class="text-secondary-400 italic"
                 >({$tAny("conversations.images", { count: $lastMessage.images.length })})</span
               >
             {/if}
           {/if}
         </span>
       </div>
-      <span class="relative flex flex-row items-center text-xs text-secondary-300">
+      <span class="text-secondary-300 relative flex flex-row items-center text-xs">
         <SvgIcon icon="person" size="8" color={$modeCurrent ? "#aaa" : "#ccc"} />
         <span class="ml-1">{Object.values($conversation.agentProfiles).length}</span>
       </span>
@@ -251,7 +253,7 @@
           />
         </button>
       {/if}
-    </a>
+    </button>
 
     <div class="absolute left-0 top-0 flex h-full w-full flex-row rounded-lg px-[1px] py-[1px]">
       <!-- <div class="flex flex-1 items-center justify-start ml-1  rounded-lg bg-secondary-500">Mark as Unread</div> -->
@@ -261,7 +263,7 @@
           : 'bg-primary-500'}"
       >
         <button
-          class="mr-2 flex flex-col items-center justify-center font-bold text-surface-100 dark:text-tertiary-100"
+          class="text-surface-100 dark:text-tertiary-100 mr-2 flex flex-col items-center justify-center font-bold"
           on:click={startArchive}
         >
           <SvgIcon icon="archive" size="20" color="white" moreClasses="" />
@@ -276,7 +278,7 @@
 
 {#if menuOpen > 0}
   <ul
-    class="absolute right-0 top-0 z-30 rounded-md border-2 bg-surface-100 p-2 shadow-md dark:bg-surface-900"
+    class="bg-surface-100 dark:bg-surface-900 absolute right-0 top-0 z-30 rounded-md border-2 p-2 shadow-md"
     style="top: {menuOpen + 22}px;"
     on:mouseover={handleHover}
     on:focus={handleHover}

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -9,6 +9,7 @@ import { platform } from "@tauri-apps/plugin-os";
 import { setModeCurrent } from "@skeletonlabs/skeleton";
 import { goto } from "$app/navigation";
 import { open } from "@tauri-apps/plugin-shell";
+import linkifyStr from "linkify-string";
 
 export const MIN_TITLE_LENGTH = 3;
 
@@ -16,15 +17,20 @@ export function sanitizeHTML(html: string) {
   return DOMPurify.sanitize(html);
 }
 
-export function linkify(text: string) {
-  const urlPattern =
-    /(?:https?:(?:\/\/)?)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
-  return text.replace(urlPattern, (match) => {
-    // XXX: not quite sure why this is needed, but if i dont do this sveltekit navigates internally and externally at the same time
-    const href = match.includes("://") ? match : `https://${match}`;
-    return `<a href="${href}" target="_blank" rel="noopener noreferrer">${match}</a>`;
+/**
+ * Search the provided text for URLs, replacing them with HTML link tags pointing to that URL
+ *
+ * @param text
+ * @returns
+ */
+export const linkify = (text: string): string =>
+  linkifyStr(text, {
+    defaultProtocol: "https",
+    rel: {
+      url: "noopener noreferrer",
+    },
+    target: "_blank",
   });
-}
 
 export function shareText(text: string | Promise<string>) {
   if (typeof text === "string") {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -50,13 +50,13 @@
       <p class="text-2xl">{$t("common.profile_error")}: {$prof.error}</p>
     </div>
   {:else}
-    <a
-      class="variant-filled-tertiary dark:variant-filled-tertiary mb-8 flex items-center rounded-full px-6 py-3"
-      href="/register"
+    <button
+      class="variant-filled-tertiary dark:variant-filled-tertiary mb-8 flex items-center rounded-full px-6 py-3 text-left"
+      on:click={() => goto("/register")}
     >
       <SvgIcon icon="lock" size="24" color="%23fd3524" />
       <span class="ml-2">{$t("common.create_an_account")}</span>
-    </a>
+    </button>
   {/if}
   <div class="flex flex-col items-center justify-center pb-10">
     <p class="mb-2 text-xs">{$t("common.secured_by")}</p>

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -319,14 +319,17 @@
 </script>
 
 <Header>
-  <a class="flex-none pr-5" href={`/conversations${conversation?.archived ? "/archive" : ""}`}
-    ><SvgIcon icon="caretLeft" color={$modeCurrent ? "%232e2e2e" : "white"} size="10" /></a
+  <button
+    class="flex-none pr-5"
+    on:click={() => goto(`/conversations${conversation?.archived ? "/archive" : ""}`)}
   >
+    <SvgIcon icon="caretLeft" color={$modeCurrent ? "%232e2e2e" : "white"} size="10" />
+  </button>
   {#if conversation}
     <h1 class="block grow self-center overflow-hidden text-ellipsis whitespace-nowrap text-center">
-      <a href={`/conversations/${conversationId}/details`} class="w-full">
+      <button on:click={() => goto(`/conversations/${conversationId}/details`)} class="w-full">
         {conversation.title}
-      </a>
+      </button>
     </h1>
     <button
       class="self-center pl-2"
@@ -335,12 +338,15 @@
       <SvgIcon icon="gear" size="18" color={$modeCurrent ? "%232e2e2e" : "white"} />
     </button>
     {#if conversation.data.privacy === Privacy.Public || encodeHashToBase64(conversation.data.progenitor) === myPubKeyB64}
-      <a
+      <button
         class="flex-none pl-5"
-        href={`/conversations/${conversation.data.id}/${conversation.data.privacy === Privacy.Public ? "details" : "invite"}`}
+        on:click={() =>
+          goto(
+            `/conversations/${conversation.data.id}/${conversation.data.privacy === Privacy.Public ? "details" : "invite"}`,
+          )}
       >
         <SvgIcon icon="addPerson" size="24" color={$modeCurrent ? "%232e2e2e" : "white"} />
-      </a>
+      </button>
     {:else}
       <span class="flex-none pl-8">&nbsp;</span>
     {/if}
@@ -394,9 +400,12 @@
       {/if}
       <h1 class="b-1 break-all text-3xl">{conversation.title}</h1>
       <!-- if joining a conversation created by someone else, say still syncing here until there are at least 2 members -->
-      <a href={`/conversations/${conversationId}/details`} class="text-sm">
+      <button
+        on:click={() => goto(`/conversations/${conversationId}/details`)}
+        class="text-left text-sm"
+      >
         {$tAny("conversations.num_members", { count: numMembers })}
-      </a>
+      </button>
       {#if $processedMessages.length === 0 && encodeHashToBase64(conversation.data.progenitor) === myPubKeyB64 && numMembers === 1}
         <!-- No messages yet, no one has joined, and this is a conversation I created. Display a helpful message to invite others -->
         <div class="flex h-full w-full flex-col items-center justify-center">

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -18,6 +18,7 @@
   import { Privacy, type Config } from "../../../../types";
   import Button from "$lib/Button.svelte";
   import toast from "svelte-french-toast";
+  import { goto } from "$app/navigation";
 
   // Silly hack to get around issues with typescript in sveltekit-i18n
   const tAny = t as any;
@@ -60,9 +61,12 @@
 </script>
 
 <Header>
-  <a class="absolute z-10 pr-5" href={`/conversations/${conversationId}`}
-    ><SvgIcon icon="caretLeft" color={$modeCurrent ? "%232e2e2e" : "white"} size="10" /></a
+  <button
+    class="absolute z-10 pr-5 text-left"
+    on:click={() => goto(`/conversations/${conversationId}`)}
   >
+    <SvgIcon icon="caretLeft" color={$modeCurrent ? "%232e2e2e" : "white"} size="10" />
+  </button>
   {#if conversation}
     <h1 class="flex-1 grow text-center">
       {#if conversation.data.privacy === Privacy.Public}{$t(
@@ -70,9 +74,12 @@
         )}{:else}{conversation.title}{/if}
     </h1>
     {#if conversation.data.privacy === Privacy.Private && encodeHashToBase64(conversation.data.progenitor) === relayStore.client.myPubKeyB64}
-      <a class="absolute right-5" href="/conversations/{conversation.data.id}/invite"
-        ><SvgIcon icon="addPerson" color="white" /></a
+      <button
+        class="absolute right-5"
+        on:click={() => goto("/conversations/{conversation.data.id}/invite")}
       >
+        <SvgIcon icon="addPerson" color="white" />
+      </button>
     {/if}
   {/if}
 </Header>


### PR DESCRIPTION
Resolves #189

- refactor: use `linkify-string` instead of custom regex for replacing URLs in messages with links
- refactor: replace all internal `<a>` links with `<button on:click={() => goto()}>` for consistent handling
- refactor: simplify the external link handler that fires anytime a click event occurs
- fix: Resolves #189
- feat: convert email addresses to `mailto:` links in messages

Extracted from #279 to reduce its scope.