### PR TITLE
refactor(ui): use conversation cell's dnaHashB64 as id, not network seed

### DIFF
--- a/ui/src/lib/ConversationSummary.svelte
+++ b/ui/src/lib/ConversationSummary.svelte
@@ -108,7 +108,7 @@
       e.preventDefault();
       e.stopPropagation();
     } else {
-      goto(`/conversations/${$conversation.id}`);
+      goto(`/conversations/${$conversation.dnaHashB64}`);
     }
   }
 

--- a/ui/src/routes/contacts/ContactEditor.svelte
+++ b/ui/src/routes/contacts/ContactEditor.svelte
@@ -83,7 +83,9 @@
       if (newContact) {
         if (!agentPubKeyB64) {
           if (newContact.privateConversation) {
-            return goto(`/conversations/${newContact.privateConversation?.id}`);
+            return goto(
+              `/conversations/${newContact.privateConversation?.data.dnaHashB64}`
+            );
           } else {
             // XXX: this shouldn't happen, but is a backup if the private conversation doesn't get created for some reason
             goto(`/contacts/${newContact.publicKeyB64}`);
@@ -345,7 +347,9 @@
       <Button
         moreClasses="variant-filled-tertiary text-sm font-bold w-auto"
         on:click={() =>
-          goto(`/conversations/${contact?.privateConversation?.id}`)}
+          goto(
+            `/conversations/${contact?.privateConversation?.data.dnaHashB64}`
+          )}
       >
         <SvgIcon
           icon="speechBubble"

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -257,7 +257,7 @@
         class="flex-none pl-5"
         on:click={() =>
           goto(
-            `/conversations/${conversation.data.id}/${conversation.data.privacy === Privacy.Public ? "details" : "invite"}`
+            `/conversations/${conversation.data.dnaHashB64}/${conversation.data.privacy === Privacy.Public ? "details" : "invite"}`
           )}
       >
         <SvgIcon

--- a/ui/src/routes/conversations/[id]/ConversationEmpty.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationEmpty.svelte
@@ -103,7 +103,8 @@
         {$t("conversations.share_personal_invitations")}
       </p>
       <Button
-        on:click={() => goto(`/conversations/${conversation.data.id}/details`)}
+        on:click={() =>
+          goto(`/conversations/${conversation.data.dnaHashB64}/details`)}
         moreClasses="w-72 justify-center"
       >
         <SvgIcon

--- a/ui/src/routes/conversations/[id]/MessageActions.svelte
+++ b/ui/src/routes/conversations/[id]/MessageActions.svelte
@@ -8,7 +8,6 @@
   import { writeFile } from "@tauri-apps/plugin-fs";
   import { downloadDir } from "@tauri-apps/api/path";
   import toast from "svelte-french-toast";
-  import { createEventDispatcher } from "svelte";
 
   export let message: Message;
 

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -66,7 +66,8 @@
     {#if conversation.data.privacy === Privacy.Private && encodeHashToBase64(conversation.data.progenitor) === relayStore.client.myPubKeyB64}
       <button
         class="absolute right-5"
-        on:click={() => goto(`/conversations/${conversation.data.id}/invite`)}
+        on:click={() =>
+          goto(`/conversations/${conversation.data.dnaHashB64}/invite`)}
       >
         <SvgIcon icon="addPerson" color="white" />
       </button>

--- a/ui/src/routes/conversations/[id]/invite/+page.svelte
+++ b/ui/src/routes/conversations/[id]/invite/+page.svelte
@@ -63,7 +63,7 @@
     try {
       if (conversation) {
         conversation.addContacts($selectedContacts);
-        goto(`/conversations/${conversation.id}/details`);
+        goto(`/conversations/${conversation.data.dnaHashB64}/details`);
       }
     } catch (e) {
       toast.error(

--- a/ui/src/routes/conversations/join/+page.svelte
+++ b/ui/src/routes/conversations/join/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { decode } from "@msgpack/msgpack";
   import { Base64 } from "js-base64";
-  import { modeCurrent } from "@skeletonlabs/skeleton";
   import { getContext } from "svelte";
   import { goto } from "$app/navigation";
   import Button from "$lib/Button.svelte";
@@ -11,10 +10,6 @@
   import { RelayClient } from "$store/RelayClient";
   import { RelayStore } from "$store/RelayStore";
   import type { Invitation } from "../../../types";
-
-  const relayClientContext: { getClient: () => RelayClient } =
-    getContext("relayClient");
-  let relayClient = relayClientContext.getClient();
 
   const relayStoreContext: { getStore: () => RelayStore } =
     getContext("relayStore");
@@ -31,7 +26,7 @@
       const invitation: Invitation = decode(msgpack) as Invitation;
       const conversation = await relayStore.joinConversation(invitation);
       if (conversation) {
-        goto(`/conversations/${conversation.data.id}`);
+        goto(`/conversations/${conversation.data.dnaHashB64}`);
         joining = false;
       } else {
         console.error(

--- a/ui/src/routes/conversations/new/+page.svelte
+++ b/ui/src/routes/conversations/new/+page.svelte
@@ -30,7 +30,7 @@
         privacy
       );
       if (conversation) {
-        goto(`/conversations/${conversation.data.id}`);
+        goto(`/conversations/${conversation.data.dnaHashB64}`);
         pendingCreate = false;
       }
     } catch (e) {

--- a/ui/src/routes/create/+page.svelte
+++ b/ui/src/routes/create/+page.svelte
@@ -79,7 +79,7 @@
 
   async function createConversation() {
     if (existingConversation) {
-      goto(`/conversations/${existingConversation.id}`);
+      goto(`/conversations/${existingConversation.data.dnaHashB64}`);
       return;
     }
 
@@ -99,7 +99,7 @@
       $selectedContacts
     );
     if (conversation) {
-      goto(`/conversations/${conversation.id}/details`);
+      goto(`/conversations/${conversation.data.dnaHashB64}/details`);
     }
     pendingCreate = false;
   }

--- a/ui/src/store/ContactStore.ts
+++ b/ui/src/store/ContactStore.ts
@@ -1,4 +1,4 @@
-import { type ActionHash, type AgentPubKeyB64 } from "@holochain/client";
+import { type ActionHash, type AgentPubKeyB64, type DnaHashB64 } from "@holochain/client";
 import { writable, get, type Writable } from "svelte/store";
 import LocalStorageStore from "$store/LocalStorageStore";
 import { RelayStore } from "$store/RelayStore";
@@ -15,10 +15,10 @@ export class ContactStore {
     public lastName: string,
     public originalActionHash: ActionHash | undefined,
     public publicKeyB64: AgentPubKeyB64,
-    public conversationId?: string | undefined,
+    public dnaHashB64?: DnaHashB64 | undefined,
   ) {
     const privateConversationId = get(
-      LocalStorageStore(`contact_${publicKeyB64}_private_conversation`, conversationId),
+      LocalStorageStore(`contact_${publicKeyB64}_private_conversation`, dnaHashB64),
     );
     this.contact = writable({
       avatar,

--- a/ui/src/store/RelayClient.ts
+++ b/ui/src/store/RelayClient.ts
@@ -10,8 +10,8 @@ import {
   type MembraneProof,
   type AgentPubKeyB64,
   type ActionHash,
+  type DnaHashB64,
 } from "@holochain/client";
-import { decode } from "@msgpack/msgpack";
 import { EntryRecord } from "@holochain-open-dev/utils";
 import type { Profile, ProfilesStore } from "@holochain-open-dev/profiles";
 import { get } from "svelte/store";
@@ -29,7 +29,7 @@ import type {
 
 export class RelayClient {
   // conversations is a map of string to ClonedCell
-  conversations: { [key: string]: ConversationCellAndConfig } = {};
+  conversations: { [dnaHashB64: DnaHashB64]: ConversationCellAndConfig } = {};
   myPubKeyB64: AgentPubKeyB64;
 
   constructor(
@@ -89,13 +89,14 @@ export class RelayClient {
         const cell = c[CellType.Cloned];
 
         try {
+          console.log("get config for ", encodeHashToBase64(cell.cell_id[0]));
           const configRecord = await this._getConfig(cell.cell_id);
 
           const config = configRecord ? configRecord.entry : { title: cell.name, image: "" };
 
           const convoCellAndConfig: ConversationCellAndConfig = { cell, config };
 
-          this.conversations[cell.dna_modifiers.network_seed] = convoCellAndConfig;
+          this.conversations[encodeHashToBase64(cell.cell_id[0])] = convoCellAndConfig;
         } catch (e) {
           console.error("Unable to get config for cell:", cell, e);
         }
@@ -139,7 +140,7 @@ export class RelayClient {
     membrane_proof?: MembraneProof,
     networkSeed?: string,
   ): Promise<ConversationCellAndConfig | null> {
-    const conversationId = networkSeed || uuidv4();
+    const newNetworkSeed = networkSeed || uuidv4();
 
     try {
       const cell = await this.client.createCloneCell({
@@ -147,7 +148,7 @@ export class RelayClient {
         name: title,
         membrane_proof,
         modifiers: {
-          network_seed: conversationId,
+          network_seed: newNetworkSeed,
           properties: {
             created,
             privacy,
@@ -163,7 +164,7 @@ export class RelayClient {
 
       await this._setMyProfileForConversation(cell.cell_id);
       const convoCellAndConfig: ConversationCellAndConfig = { cell, config };
-      this.conversations[conversationId] = convoCellAndConfig;
+      this.conversations[encodeHashToBase64(cell.cell_id[0])] = convoCellAndConfig;
       return convoCellAndConfig;
     } catch (e) {
       console.error("Error creating conversation", e);
@@ -172,11 +173,11 @@ export class RelayClient {
   }
 
   public async getAllMessages(
-    conversationId: string,
+    dnaHashB64: DnaHashB64,
     buckets: Array<number>,
   ): Promise<Array<MessageRecord>> {
     return this.client.callZome({
-      cell_id: this.conversations[conversationId].cell.cell_id,
+      cell_id: this.conversations[dnaHashB64].cell.cell_id,
       zome_name: this.zomeName,
       fn_name: "get_messages_for_buckets",
       payload: buckets,
@@ -184,12 +185,12 @@ export class RelayClient {
   }
 
   public async getMessageHashes(
-    conversationId: string,
+    dnaHashB64: DnaHashB64,
     bucket: number,
     count: number,
   ): Promise<Array<ActionHash>> {
     return this.client.callZome({
-      cell_id: this.conversations[conversationId].cell.cell_id,
+      cell_id: this.conversations[dnaHashB64].cell.cell_id,
       zome_name: this.zomeName,
       fn_name: "get_message_hashes",
       payload: { bucket, count },
@@ -197,19 +198,19 @@ export class RelayClient {
   }
 
   public async getMessageEntries(
-    conversationId: string,
+    dnaHashB64: DnaHashB64,
     hashes: Array<ActionHash>,
   ): Promise<Array<MessageRecord>> {
     return this.client.callZome({
-      cell_id: this.conversations[conversationId].cell.cell_id,
+      cell_id: this.conversations[dnaHashB64].cell.cell_id,
       zome_name: this.zomeName,
       fn_name: "get_message_entries",
       payload: hashes,
     });
   }
 
-  public async getAllAgents(conversationId: string): Promise<{ [key: AgentPubKeyB64]: Profile }> {
-    const cellId = this.conversations[conversationId].cell.cell_id;
+  public async getAllAgents(dnaHashB64: DnaHashB64): Promise<{ [key: AgentPubKeyB64]: Profile }> {
+    const cellId = this.conversations[dnaHashB64].cell.cell_id;
 
     // Fetcha all AgentPubKeys of agents with profiles
     const agentsResponse: AgentPubKey[] = await this.client.callZome({
@@ -249,8 +250,8 @@ export class RelayClient {
     });
   }
 
-  async _getConfig(id: CellId | string): Promise<EntryRecord<Config> | undefined> {
-    const cellId = typeof id === "string" ? this.conversations[id].cell.cell_id : id;
+  async _getConfig(cellId: CellId): Promise<EntryRecord<Config> | undefined> {
+    console.log("cell id is", cellId);
 
     const config = await this.client.callZome({
       cell_id: cellId,
@@ -262,14 +263,14 @@ export class RelayClient {
   }
 
   public async sendMessage(
-    conversationId: string,
+    dnaHashB64: DnaHashB64,
     content: string,
     bucket: number,
     images: ImageStruct[],
     agents: AgentPubKey[],
   ): Promise<EntryRecord<Message>> {
     const message = await this.client.callZome({
-      cell_id: this.conversations[conversationId].cell.cell_id,
+      cell_id: this.conversations[dnaHashB64].cell.cell_id,
       zome_name: this.zomeName,
       fn_name: "create_message",
       payload: {
@@ -295,12 +296,12 @@ export class RelayClient {
   }
 
   public async inviteAgentToConversation(
-    conversationId: string,
+    dnaHashB64: DnaHashB64,
     forAgent: AgentPubKey,
     role: number = 0,
   ): Promise<MembraneProof | undefined> {
     try {
-      const conversation = this.conversations[conversationId];
+      const conversation = this.conversations[dnaHashB64];
 
       const data: MembraneProofData = {
         conversation_id: conversation.cell.dna_modifiers.network_seed,

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -9,6 +9,7 @@ import {
   encodeHashToBase64,
   type Signal,
   SignalType,
+  type DnaHashB64,
 } from "@holochain/client";
 import { ContactStore } from "./ContactStore";
 import { ConversationStore } from "./ConversationStore";
@@ -106,10 +107,9 @@ export class RelayStore {
     ) as Properties;
     const progenitor = decodeHashFromBase64(properties.progenitor);
     const privacy = properties.privacy;
-    const seed = convoCellAndConfig.cell.dna_modifiers.network_seed;
     const newConversation = new ConversationStore(
       this,
-      seed,
+      convoCellAndConfig.cell.dna_modifiers.network_seed,
       convoCellAndConfig.cell.cell_id,
       convoCellAndConfig.config,
       properties.created,
@@ -166,15 +166,17 @@ export class RelayStore {
     return null;
   }
 
-  async inviteAgentToConversation(conversationId: string, agent: AgentPubKey, role: number = 0) {
+  async inviteAgentToConversation(dnaHashB64: DnaHashB64, agent: AgentPubKey, role: number = 0) {
     if (!this.client) return;
-    return await this.client.inviteAgentToConversation(conversationId, agent, role);
+    return await this.client.inviteAgentToConversation(dnaHashB64, agent, role);
   }
 
-  getConversation(id: string): ConversationStore | undefined {
+  getConversation(dnaHashB64: DnaHashB64): ConversationStore | undefined {
     let foundConversation;
     this.conversations.subscribe((conversations) => {
-      foundConversation = conversations.find((conversation) => conversation.data.id === id);
+      foundConversation = conversations.find(
+        (conversation) => conversation.data.dnaHashB64 === dnaHashB64,
+      );
     })();
 
     return foundConversation;
@@ -237,7 +239,7 @@ export class RelayStore {
         contact.lastName,
         contactResult.signed_action.hashed.hash,
         contact.publicKeyB64,
-        conversation?.id,
+        conversation?.data.dnaHashB64,
       );
       this.contacts.update((contacts) => [...contacts, contactStore]);
       return contactStore;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -12,6 +12,7 @@ import type {
   DeleteLink,
   MembraneProof,
   ClonedCell,
+  DnaHashB64,
 } from "@holochain/client";
 
 import type { Profile } from "@holochain-open-dev/profiles";
@@ -82,7 +83,8 @@ export interface MessageInput {
 export type Messages = { [key: string]: Message };
 
 export interface Conversation {
-  id: string; // the network seed
+  networkSeed: string;
+  dnaHashB64: DnaHashB64;
   cellId: CellId;
   config: Config;
   description?: string;


### PR DESCRIPTION
Extracted from #279 

- use conversation cell's dnaHashB64 as id, not network seed
- rename all usage from `id` -> `dnaHashB64` for clarity
- remove duck-typing of getConfig function