### PR TITLE
refactor(ui): use svelte custom stores for BucketStore and MessageHistoryStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8348,6 +8348,17 @@
         "svelte": "^3.19.0 || ^4.0.0"
       }
     },
+    "node_modules/svelte-persisted-store": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/svelte-persisted-store/-/svelte-persisted-store-0.12.0.tgz",
+      "integrity": "sha512-BdBQr2SGSJ+rDWH8/aEV5GthBJDapVP0GP3fuUCA7TjYG5ctcB+O9Mj9ZC0+Jo1oJMfZUd1y9H68NFRR5MyIJA==",
+      "engines": {
+        "node": ">=0.14"
+      },
+      "peerDependencies": {
+        "svelte": "^3.48.0 || ^4 || ^5"
+      }
+    },
     "node_modules/svelte-preprocess": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.4.tgz",
@@ -9240,6 +9251,7 @@
         "p-retry": "^6.2.0",
         "svelte-french-toast": "^1.2.0",
         "svelte-gestures": "^5.0.6",
+        "svelte-persisted-store": "^0.12.0",
         "svelte-qrcode-image": "^2.0.0-alpha.1",
         "sveltekit-i18n": "^2.4.2",
         "uuid": "^10.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,7 @@
     "p-retry": "^6.2.0",
     "svelte-french-toast": "^1.2.0",
     "svelte-gestures": "^5.0.6",
+    "svelte-persisted-store": "^0.12.0",
     "svelte-qrcode-image": "^2.0.0-alpha.1",
     "sveltekit-i18n": "^2.4.2",
     "uuid": "^10.0.0"

--- a/ui/src/store/BucketStore.ts
+++ b/ui/src/store/BucketStore.ts
@@ -1,27 +1,54 @@
-import type { ActionHashB64 } from "@holochain/client";
-import { get, writable, type Writable } from "svelte/store";
+import type { ActionHashB64, DnaHashB64 } from "@holochain/client";
+import { persisted } from "svelte-persisted-store";
+import { derived, get, type Invalidator, type Subscriber, type Unsubscriber } from "svelte/store";
 
-export class BucketStore {
-  public hashes: Writable<Set<ActionHashB64>> = writable(new Set());
+export interface BucketStore {
+  add: (hashes: ActionHashB64[]) => void;
+  missingHashes: (allHashes: ActionHashB64[]) => ActionHashB64[];
+  subscribe: (
+    this: void,
+    run: Subscriber<{
+      hashes: string[];
+      count: number;
+    }>,
+    invalidate?:
+      | Invalidator<{
+          hashes: string[];
+          count: number;
+        }>
+      | undefined,
+  ) => Unsubscriber;
+}
 
-  constructor(hashes: Array<ActionHashB64>) {
-    this.hashes.set(new Set(hashes));
+export function createBucketStore(
+  dnaHashB64: DnaHashB64,
+  bucket: number,
+  initialHashes: ActionHashB64[] = [],
+) {
+  const hashes = persisted(
+    `CONVERSATIONS.${dnaHashB64}.BUCKETS.${bucket}`,
+    Array.from(new Set(initialHashes)),
+    { storage: "local" },
+  );
+
+  const { subscribe } = derived(hashes, ($hashes) => {
+    return {
+      hashes: $hashes,
+      count: $hashes.length,
+    };
+  });
+
+  function add(newHashes: ActionHashB64[]) {
+    hashes.update(($hashes) => Array.from(new Set([...$hashes, ...newHashes])));
   }
 
-  get count(): number {
-    return get(this.hashes).size;
+  function missingHashes(allHashes: ActionHashB64[]): ActionHashB64[] {
+    return Array.from(new Set(allHashes).difference(new Set(get(hashes))));
   }
 
-  toJSON(): string {
-    return JSON.stringify(Array.from(get(this.hashes)!.keys()));
-  }
-
-  add(newHashes: Array<ActionHashB64>) {
-    this.hashes.update((h) => new Set([...h, ...newHashes]));
-  }
-
-  missingHashes(hashes: Array<ActionHashB64>): Array<ActionHashB64> {
-    const s: Set<ActionHashB64> = new Set(hashes);
-    return Array.from(s.difference(get(this.hashes)));
-  }
+  return {
+    add,
+    missingHashes,
+    subscribe,
+  };
 }

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -27,7 +27,7 @@ import {
   Privacy,
   type Messages,
 } from "../types";
-import { MessageHistoryStore } from "./MessageHistoryStore";
+import { createMessageHistoryStore, type MessageHistoryStore } from "./MessageHistoryStore";
 import pRetry from "p-retry";
 import { fileToDataUrl } from "$lib/utils";
 import toast from "svelte-french-toast";
@@ -55,11 +55,13 @@ export class ConversationStore {
     const messages: Messages = {};
 
     const currentBucket = this.currentBucket();
-    this.history = new MessageHistoryStore(currentBucket, encodeHashToBase64(this.cellId[0]));
+
+    const dnaHashB64 = encodeHashToBase64(this.cellId[0]);
+    this.history = createMessageHistoryStore(dnaHashB64, currentBucket);
 
     this.conversation = writable({
       networkSeed,
-      dnaHashB64: encodeHashToBase64(cellId[0]),
+      dnaHashB64,
       cellId,
       config,
       privacy,
@@ -300,7 +302,7 @@ export class ConversationStore {
       const messageHashes = await this.client.getMessageHashes(
         this.data.dnaHashB64,
         b,
-        bucket.count,
+        get(bucket).count,
       );
 
       const messageHashesB64 = messageHashes.map((h) => encodeHashToBase64(h));
@@ -310,11 +312,10 @@ export class ConversationStore {
           this.localDataStore.update((data) => ({ ...data, unread: true }));
         }
         bucket.add(missingHashes);
-        this.history.saveBucket(b);
       }
 
       const hashesToLoad: Array<ActionHash> = [];
-      get(bucket.hashes).forEach((h) => {
+      get(bucket).hashes.forEach((h) => {
         if (!newMessages[h]) hashesToLoad.push(decodeHashFromBase64(h));
       });
 

--- a/ui/src/store/MessageHistoryStore.ts
+++ b/ui/src/store/MessageHistoryStore.ts
@@ -1,78 +1,78 @@
 import { type DnaHashB64 } from "@holochain/client";
 import type { Message } from "../types";
-import { BucketStore } from "./BucketStore";
-import { derived, get, type Readable, writable, type Writable } from "svelte/store";
+import { createBucketStore, type BucketStore } from "./BucketStore";
+import { derived, get, type Invalidator, type Subscriber, type Unsubscriber } from "svelte/store";
+import { range, sum } from "lodash-es";
 
-export class MessageHistoryStore {
-  private buckets: Writable<BucketStore[]>;
-  public messageCount: Readable<number>;
+export interface MessageHistoryStore {
+  add: (message: Message) => void;
+  getBucket: (b: number) => BucketStore;
+  bucketsForSet: (setSize: number, startingBucket: number) => number[];
+  subscribe: (
+    this: void,
+    run: Subscriber<{
+      buckets: {
+        hashes: string[];
+        count: number;
+      }[];
+      messageCount: number;
+    }>,
+    invalidate?:
+      | Invalidator<{
+          buckets: {
+            hashes: string[];
+            count: number;
+          }[];
+          messageCount: number;
+        }>
+      | undefined,
+  ) => Unsubscriber;
+}
 
-  constructor(
-    currentBucket: number,
-    private dnaHashB64: DnaHashB64,
-  ) {
-    const buckets: BucketStore[] = [];
-    for (let b = 0; b <= currentBucket; b += 1) {
-      const bucketJSON = localStorage.getItem(`c.${this.dnaHashB64}.${b}`);
-      const initialBuckets = bucketJSON ? JSON.parse(bucketJSON) : [];
-      buckets[b] = new BucketStore(initialBuckets);
-    }
+export function createMessageHistoryStore(dnaHashB64: DnaHashB64, currentBucket: number) {
+  const buckets: BucketStore[] = range(0, currentBucket).map((i) =>
+    createBucketStore(dnaHashB64, i),
+  );
+  const { subscribe } = derived(buckets, ($buckets) => ({
+    buckets: $buckets,
+    messageCount: sum($buckets.map((b) => b.count)),
+  }));
 
-    this.buckets = writable(buckets);
-    this.messageCount = derived(this.buckets, ($b) => {
-      let count = 0;
-      $b.forEach((b) => (count += b.count));
-      return count;
-    });
-  }
-
-  bucketsForSet(setSize: number, startingBucket: number): number[] {
-    let bucket = startingBucket;
+  function bucketsForSet(setSize: number, startingBucket: number): number[] {
+    let i = startingBucket;
     const bucketsInSet: Array<number> = [];
     let count = 0;
     // add buckets until we get to threshold of what to load
-    let buckets = get(this.buckets);
     do {
-      bucketsInSet.push(bucket);
-      const h = buckets[bucket];
-      if (h) {
-        const size = h.count;
-        count += size;
+      bucketsInSet.push(i);
+      if (buckets[i]) {
+        count += get(buckets[i]).count;
       }
-      bucket -= 1;
-    } while (bucket >= 0 && count < setSize);
+      i -= 1;
+    } while (i >= 0 && count < setSize);
     return bucketsInSet;
   }
 
-  ensure(b: number) {
-    if (get(this.buckets)[b] == undefined) {
-      this.buckets.update((buckets) => {
-        buckets[b] = new BucketStore([]);
-        return buckets;
-      });
-    }
-  }
-  getBucket(b: number): BucketStore {
-    this.ensure(b);
-    let buckets = get(this.buckets);
+  function getBucket(b: number): BucketStore {
+    _ensure(b);
     return buckets[b];
   }
 
-  add(message: Message) {
-    this.buckets.update((buckets) => {
-      const bucket = buckets[message.bucket];
-      if (bucket === undefined) {
-        buckets[message.bucket] = new BucketStore([message.hash]);
-      } else {
-        bucket.add([message.hash]);
-      }
-      return buckets;
-    });
-    this.saveBucket(message.bucket);
+  function add(message: Message) {
+    _ensure(message.bucket);
+    buckets[message.bucket].add([message.hash]);
   }
 
-  saveBucket(b: number) {
-    const bucket = this.getBucket(b);
-    localStorage.setItem(`c.${this.dnaHashB64}.${b}`, bucket.toJSON());
+  function _ensure(b: number) {
+    if (get(buckets[b]) == undefined) {
+      buckets[b] = createBucketStore(dnaHashB64, b);
+    }
   }
+
+  return {
+    add,
+    getBucket,
+    bucketsForSet,
+    subscribe,
+  };
 }


### PR DESCRIPTION
Extracted from #279 
- convert BucketStore and MessageHistoryStore to svelte custom stores instead of classes
- don't wrap child custom stores in writables.