### PR TITLE
fix(ui): conversation/[id]/invitations was only available as a route for private conversations

### DIFF
--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -156,18 +156,14 @@
     >
       <SvgIcon icon="gear" size="18" color={$modeCurrent ? "%232e2e2e" : "white"} />
     </button>
-    {#if $conversationStore && ($conversationStore.conversation.privacy === Privacy.Public || encodeHashToBase64($conversationStore.conversation.progenitor) === myPubKeyB64)}
+    {#if $conversationStore && $conversationStore.conversation.privacy === Privacy.Private && encodeHashToBase64($conversationStore.conversation.progenitor) === myPubKeyB64}
       <button
         class="flex-none pl-5"
         on:click={() =>
-          goto(
-            `/conversations/${$conversationStore?.conversation.dnaHashB64}/${$conversationStore.conversation.privacy === Privacy.Public ? "details" : "invite"}`,
-          )}
+          goto(`/conversations/${$conversationStore?.conversation.dnaHashB64}/invite`)}
       >
         <SvgIcon icon="addPerson" size="24" color={$modeCurrent ? "%232e2e2e" : "white"} />
       </button>
-    {:else}
-      <span class="flex-none pl-8">&nbsp;</span>
     {/if}
   {/if}
 </Header>

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -216,39 +216,24 @@
             {/if}
           </li>
         {/if}
-        {#if conversationStore.getInvitedUnjoined().length > 0}
-          <h3 class="text-md text-secondary-300 mb-2 font-light">
-            {$t("conversations.unconfirmed_invitations")}
-          </h3>
-          {#each conversationStore.getInvitedUnjoined() as contact}
-            <li class="mb-4 flex flex-row items-center px-2 text-xl">
-              <Avatar
-                image={contact.avatar}
-                agentPubKey={contact.publicKeyB64}
-                size="38"
-                moreClasses="-ml-30"
-              />
-              <span class="ml-4 flex-1 text-sm"
-                >{makeFullName(contact.firstName || "", contact.lastName)}</span
-              >
-              <button
-                class="variant-filled-tertiary flex items-center justify-center rounded-2xl p-2 px-3 text-sm font-bold"
-                on:click={async () => {
-                  try {
-                    const inviteCode = await conversationStore.makeInviteCodeForAgent(
-                      contact.publicKeyB64,
-                    );
-                    await copyToClipboard(inviteCode);
-                    toast.success(`${$t("common.copy_success")}`);
-                  } catch (e) {
-                    toast.error(`${$t("common.copy_error")}: ${e.message}`);
-                  }
-                }}
-              >
-                <SvgIcon icon="copy" size="18" color="%23FD3524" moreClasses="mr-2" />
-                {$t("conversations.copy_invite")}
-              </button>
-              {#if isMobile()}
+
+        {#if $conversationStore.conversation.privacy === Privacy.Private}
+          {#if conversationStore.getInvitedUnjoined().length > 0}
+            <h3 class="text-md text-secondary-300 mb-2 font-light">
+              {$t("conversations.unconfirmed_invitations")}
+            </h3>
+
+            {#each conversationStore.getInvitedUnjoined() as contact}
+              <li class="mb-4 flex flex-row items-center px-2 text-xl">
+                <Avatar
+                  image={contact.avatar}
+                  agentPubKey={contact.publicKeyB64}
+                  size="38"
+                  moreClasses="-ml-30"
+                />
+                <span class="ml-4 flex-1 text-sm"
+                  >{makeFullName(contact.firstName || "", contact.lastName)}</span
+                >
                 <button
                   class="variant-filled-tertiary flex items-center justify-center rounded-2xl p-2 px-3 text-sm font-bold"
                   on:click={async () => {
@@ -256,21 +241,38 @@
                       const inviteCode = await conversationStore.makeInviteCodeForAgent(
                         contact.publicKeyB64,
                       );
-                      if (!inviteCode) throw new Error("Failed to generate invite code");
-                      await shareText(inviteCode);
+                      await copyToClipboard(inviteCode);
+                      toast.success(`${$t("common.copy_success")}`);
                     } catch (e) {
-                      toast.error(`${$t("common.share_code_error")}: ${e.message}`);
+                      toast.error(`${$t("common.copy_error")}: ${e.message}`);
                     }
                   }}
                 >
-                  <SvgIcon icon="share" size="18" color="%23FD3524" moreClasses="mr-2" />
+                  <SvgIcon icon="copy" size="18" color="%23FD3524" moreClasses="mr-2" />
+                  {$t("conversations.copy_invite")}
                 </button>
-              {/if}
-            </li>
-          {/each}
-        {/if}
+                {#if isMobile()}
+                  <button
+                    class="variant-filled-tertiary flex items-center justify-center rounded-2xl p-2 px-3 text-sm font-bold"
+                    on:click={async () => {
+                      try {
+                        const inviteCode = await conversationStore.makeInviteCodeForAgent(
+                          contact.publicKeyB64,
+                        );
+                        if (!inviteCode) throw new Error("Failed to generate invite code");
+                        await shareText(inviteCode);
+                      } catch (e) {
+                        toast.error(`${$t("common.share_code_error")}: ${e.message}`);
+                      }
+                    }}
+                  >
+                    <SvgIcon icon="share" size="18" color="%23FD3524" moreClasses="mr-2" />
+                  </button>
+                {/if}
+              </li>
+            {/each}
+          {/if}
 
-        {#if $conversationStore.conversation.privacy === Privacy.Private}
           <h3 class="text-md text-secondary-300 mb-2 mt-4 font-light">
             {$t("conversations.members")}
           </h3>


### PR DESCRIPTION
Extracted from #279

The page `conversation/[id]/invite` was only accessible via a button on the conversation page. The button would only navigate to `/invite` when the conversation is private and the user is the progenitor, otherwise the button would navigate to `/details`

This PR
- removes the button for public conversations, as it was redundant (another button next to it already navigates to `/details`
- removes all conditional logic for public conversations in the `/invite` page component
- moves all logic for displaying "invited" agents into conditionals for private conversations, as there is no support for inviting agents to public conversations