### PR TITLE
refactor(ui): pass holochain client's myPubKey as svelte context

### DIFF
--- a/ui/src/lib/SvgIcon.svelte
+++ b/ui/src/lib/SvgIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { svgIcons } from "./svgIcons";
+  import { svgIcons } from "$lib/svgIcons";
 
   export let icon: string;
   export let style: string = "";

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -6,17 +6,16 @@
   import { onMount, setContext } from "svelte";
   import SvgIcon from "$lib/SvgIcon.svelte";
   import { t } from "$translations";
-  import { RelayClient } from "$store/RelayClient";
   import { RelayStore } from "$store/RelayStore";
   import toast, { Toaster } from "svelte-french-toast";
   import { handleLinkClick, initLightDarkModeSwitcher } from "$lib/utils";
   import "../app.postcss";
+  import { RelayClient } from "$store/RelayClient";
 
   const ROLE_NAME = "relay";
   const ZOME_NAME = "relay";
 
   let client: AppClient;
-  let relayClient: RelayClient;
   let relayStore: RelayStore;
   let connected = false;
   let profilesStore: ProfilesStore | null = null;
@@ -56,7 +55,7 @@
       // Setup stores
       let profilesClient = new ProfilesClient(client, ROLE_NAME);
       profilesStore = new ProfilesStore(profilesClient);
-      relayClient = new RelayClient(client, profilesStore, ROLE_NAME, ZOME_NAME);
+      const relayClient = new RelayClient(client, profilesStore, ROLE_NAME, ZOME_NAME);
       relayStore = new RelayStore(relayClient);
       await relayStore.initialize();
 
@@ -84,10 +83,6 @@
   });
 
   $: prof = profilesStore ? profilesStore.myProfile : undefined;
-
-  setContext("relayClient", {
-    getClient: () => relayClient,
-  });
 
   setContext("myPubKey", {
     getMyPubKey: () => client.myPubKey,

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { AppClient } from "@holochain/client";
-  import { AppWebsocket } from "@holochain/client";
+  import { AppWebsocket, encodeHashToBase64 } from "@holochain/client";
   import { ProfilesClient, ProfilesStore } from "@holochain-open-dev/profiles";
   import { modeCurrent } from "@skeletonlabs/skeleton";
   import { onMount, setContext } from "svelte";
@@ -87,6 +87,11 @@
 
   setContext("relayClient", {
     getClient: () => relayClient,
+  });
+
+  setContext("myPubKey", {
+    getMyPubKey: () => client.myPubKey,
+    getMyPubKeyB64: () => encodeHashToBase64(client.myPubKey),
   });
 
   setContext("profiles", {

--- a/ui/src/routes/account/+page.svelte
+++ b/ui/src/routes/account/+page.svelte
@@ -7,7 +7,6 @@
   import SvgIcon from "$lib/SvgIcon.svelte";
   import { t } from "$translations";
   import { makeFullName } from "$lib/utils";
-  import { RelayClient } from "$store/RelayClient";
   import { ProfilesStore } from "@holochain-open-dev/profiles";
   import { get } from "svelte/store";
   import toast from "svelte-french-toast";
@@ -16,9 +15,9 @@
   import ButtonsCopyShare from "$lib/ButtonsCopyShare.svelte";
   import ProfileNameInput from "./ProfileNameInput.svelte";
   import type { AgentPubKey, AgentPubKeyB64 } from "@holochain/client";
+  import type { RelayStore } from "$store/RelayStore";
 
-  const relayClientContext: { getClient: () => RelayClient } = getContext("relayClient");
-  let relayClient = relayClientContext.getClient();
+  const relayStore = getContext<{ getStore: () => RelayStore }>("relayStore").getStore();
 
   const profilesContext: { getStore: () => ProfilesStore } = getContext("profiles");
   let profilesStore = profilesContext.getStore();
@@ -41,7 +40,7 @@
     console.log("save", newFirstName, newLastName);
 
     try {
-      await relayClient.updateProfile(newFirstName, newLastName, avatar);
+      await relayStore.client.updateProfile(newFirstName, newLastName, avatar);
       firstName = newFirstName;
       lastName = newLastName;
     } catch (e) {
@@ -64,7 +63,7 @@
     accept="image/jpeg, image/png, image/gif"
     on:change={(event) => {
       try {
-        relayClient.updateProfile(firstName, lastName, event.detail);
+        relayStore.client.updateProfile(firstName, lastName, event.detail);
       } catch (e) {
         toast.error(`${$t("common.upload_image_error")}: ${e.message}`);
       }

--- a/ui/src/routes/account/+page.svelte
+++ b/ui/src/routes/account/+page.svelte
@@ -15,6 +15,7 @@
   import { MIN_FIRST_NAME_LENGTH } from "$config";
   import ButtonsCopyShare from "$lib/ButtonsCopyShare.svelte";
   import ProfileNameInput from "./ProfileNameInput.svelte";
+  import type { AgentPubKey, AgentPubKeyB64 } from "@holochain/client";
 
   const relayClientContext: { getClient: () => RelayClient } = getContext("relayClient");
   let relayClient = relayClientContext.getClient();
@@ -22,7 +23,11 @@
   const profilesContext: { getStore: () => ProfilesStore } = getContext("profiles");
   let profilesStore = profilesContext.getStore();
 
-  const agentPublicKey64 = relayClient.myPubKeyB64;
+  const agentPublicKey64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
+    "myPubKey",
+  ).getMyPubKeyB64();
+
+  const myPubKey = getContext<{ getMyPubKey: () => AgentPubKey }>("myPubKey").getMyPubKey();
 
   let firstName = get(profilesStore.myProfile).value?.entry.fields.firstName || "";
   let lastName = get(profilesStore.myProfile).value?.entry.fields.lastName || "";
@@ -67,7 +72,7 @@
   />
 
   <div style="position:relative">
-    <Avatar agentPubKey={relayClient.myPubKey} size={128} moreClasses="mb-4" />
+    <Avatar agentPubKey={myPubKey} size={128} moreClasses="mb-4" />
     <label
       for="avatarInput"
       class="bg-tertiary-500 hover:bg-secondary-300 dark:bg-secondary-500 dark:hover:bg-secondary-400 absolute bottom-5 right-0 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full pl-1"

--- a/ui/src/routes/contacts/ContactEditor.svelte
+++ b/ui/src/routes/contacts/ContactEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { isEmpty } from "lodash-es";
   import { modeCurrent } from "@skeletonlabs/skeleton";
-  import { getContext, onMount } from "svelte";
+  import { getContext } from "svelte";
   import { decodeHashFromBase64, type AgentPubKeyB64, type HoloHash } from "@holochain/client";
   import { goto } from "$app/navigation";
   import Button from "$lib/Button.svelte";
@@ -18,6 +18,10 @@
 
   const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
   let relayStore = relayStoreContext.getStore();
+
+  const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
+    "myPubKey",
+  ).getMyPubKeyB64();
 
   export let agentPubKeyB64: AgentPubKeyB64 | null = null;
   export let creating = false;
@@ -47,7 +51,7 @@
       } else if (!agentPubKeyB64 && contacts.find((c) => get(c).publicKeyB64 === publicKeyB64)) {
         valid = false;
         error = $t("contacts.contact_already_exist");
-      } else if (relayStore.client.myPubKeyB64 === publicKeyB64) {
+      } else if (myPubKeyB64 === publicKeyB64) {
         valid = false;
         error = $t("contacts.cant_add_yourself");
       } else {

--- a/ui/src/routes/conversations/+page.svelte
+++ b/ui/src/routes/conversations/+page.svelte
@@ -9,9 +9,12 @@
   import SvgIcon from "$lib/SvgIcon.svelte";
   import { RelayStore } from "$store/RelayStore";
   import ConversationSummary from "$lib/ConversationSummary.svelte";
+  import type { AgentPubKey } from "@holochain/client";
 
   const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
   let relayStore = relayStoreContext.getStore();
+
+  const myPubKey = getContext<{ getMyPubKey: () => AgentPubKey }>("myPubKey").getMyPubKey();
 
   let search = "";
 
@@ -42,7 +45,7 @@
 
 <Header>
   <button on:click={() => goto("/account")} class="flex flex-1 items-start">
-    <Avatar size={24} agentPubKey={relayStore.client.myPubKey} />
+    <Avatar size={24} agentPubKey={myPubKey} />
   </button>
 
   <button on:click={() => goto("/create")} class="">

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { debounce } from "lodash-es";
-  import { encodeHashToBase64 } from "@holochain/client";
+  import { encodeHashToBase64, type AgentPubKeyB64 } from "@holochain/client";
   import { modeCurrent } from "@skeletonlabs/skeleton";
   import { getContext, onDestroy, onMount } from "svelte";
   import { page } from "$app/stores";
@@ -20,7 +20,10 @@
 
   const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
   let relayStore = relayStoreContext.getStore();
-  let myPubKeyB64 = relayStore.client.myPubKeyB64;
+
+  const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
+    "myPubKey",
+  ).getMyPubKeyB64();
 
   let conversationStore = relayStore.getConversation($page.params.id);
 

--- a/ui/src/routes/conversations/[id]/Message.svelte
+++ b/ui/src/routes/conversations/[id]/Message.svelte
@@ -14,8 +14,6 @@
   import { clickoutside } from "@svelte-put/clickoutside";
   import type { AgentPubKeyB64 } from "@holochain/client";
 
-  const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
-  let relayStore = relayStoreContext.getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
     "myPubKey",
   ).getMyPubKeyB64();

--- a/ui/src/routes/conversations/[id]/Message.svelte
+++ b/ui/src/routes/conversations/[id]/Message.svelte
@@ -12,10 +12,13 @@
   import DOMPurify from "dompurify";
   import linkifyStr from "linkify-string";
   import { clickoutside } from "@svelte-put/clickoutside";
+  import type { AgentPubKeyB64 } from "@holochain/client";
 
   const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
   let relayStore = relayStoreContext.getStore();
-  let myPubKeyB64 = relayStore.client.myPubKeyB64;
+  const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
+    "myPubKey",
+  ).getMyPubKeyB64();
 
   export let message: MessageType;
   export let isSelected: boolean = false;

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { modeCurrent } from "@skeletonlabs/skeleton";
   import { getContext } from "svelte";
-  import { encodeHashToBase64 } from "@holochain/client";
+  import { encodeHashToBase64, type AgentPubKeyB64 } from "@holochain/client";
   import { page } from "$app/stores";
   import Avatar from "$lib/Avatar.svelte";
   import Header from "$lib/Header.svelte";
@@ -20,7 +20,10 @@
 
   const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
   let relayStore = relayStoreContext.getStore();
-  const myPublicKey64 = relayStore.client.myPubKeyB64;
+  const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
+    "myPubKey",
+  ).getMyPubKeyB64();
+
   let conversationStore = relayStore.getConversation($page.params.id);
 
   // used for editing Group conversation details
@@ -51,7 +54,7 @@
           "conversations.group_details",
         )}{:else}{conversationStore.getTitle()}{/if}
     </h1>
-    {#if $conversationStore.conversation.privacy === Privacy.Private && encodeHashToBase64($conversationStore.conversation.progenitor) === relayStore.client.myPubKeyB64}
+    {#if $conversationStore.conversation.privacy === Privacy.Private && encodeHashToBase64($conversationStore.conversation.progenitor) === myPubKeyB64}
       <button
         class="absolute right-5"
         on:click={() => goto(`/conversations/${$conversationStore.conversation.dnaHashB64}/invite`)}
@@ -195,9 +198,9 @@
           </h3>
         {/if}
         <li class="mb-4 flex flex-row items-center px-2 text-xl">
-          <Avatar agentPubKey={myPublicKey64} size={38} moreClasses="-ml-30" />
+          <Avatar agentPubKey={myPubKeyB64} size={38} moreClasses="-ml-30" />
           <span class="ml-4 flex-1 text-sm font-bold">{$t("conversations.you")}</span>
-          {#if myPublicKey64 === encodeHashToBase64($conversationStore.conversation.progenitor)}
+          {#if myPubKeyB64 === encodeHashToBase64($conversationStore.conversation.progenitor)}
             <span class="text-secondary-300 ml-2 text-xs">{$t("conversations.admin")}</span>
           {/if}
         </li>

--- a/ui/src/routes/register/avatar/+page.svelte
+++ b/ui/src/routes/register/avatar/+page.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
-  import { modeCurrent } from "@skeletonlabs/skeleton";
   import { getContext } from "svelte";
   import { goto } from "$app/navigation";
   import Button from "$lib/Button.svelte";
   import Header from "$lib/Header.svelte";
-  import SvgIcon from "$lib/SvgIcon.svelte";
   import { t } from "$translations";
-  import { RelayClient } from "$store/RelayClient";
   import { ProfileCreateStore } from "$store/ProfileCreateStore";
   import toast from "svelte-french-toast";
   import HiddenFileInput from "$lib/HiddenFileInput.svelte";
+  import type { RelayStore } from "$store/RelayStore";
 
-  const relayClientContext: { getClient: () => RelayClient } = getContext("relayClient");
-  let relayClient = relayClientContext.getClient();
+  const relayStore = getContext<{ getStore: () => RelayStore }>("relayStore").getStore();
 
   let firstName = "";
   let lastName = "";
@@ -29,7 +26,7 @@
 
   async function createAccount() {
     try {
-      await relayClient.createProfile(firstName, lastName, avatarDataUrl);
+      await relayStore.client.createProfile(firstName, lastName, avatarDataUrl);
       goto("/welcome");
     } catch (e) {
       toast.error(`${$t("common.create_account_error")}: ${e.message}`);

--- a/ui/src/routes/welcome/+page.svelte
+++ b/ui/src/routes/welcome/+page.svelte
@@ -6,8 +6,6 @@
   import Header from "$lib/Header.svelte";
   import SvgIcon from "$lib/SvgIcon.svelte";
   import { t } from "$translations";
-
-  import { RelayClient } from "$store/RelayClient";
   import { RelayStore } from "$store/RelayStore";
   import type { AgentPubKey } from "@holochain/client";
 

--- a/ui/src/routes/welcome/+page.svelte
+++ b/ui/src/routes/welcome/+page.svelte
@@ -9,12 +9,12 @@
 
   import { RelayClient } from "$store/RelayClient";
   import { RelayStore } from "$store/RelayStore";
-
-  const relayClientContext: { getClient: () => RelayClient } = getContext("relayClient");
-  let relayClient = relayClientContext.getClient();
+  import type { AgentPubKey } from "@holochain/client";
 
   const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
   let relayStore = relayStoreContext.getStore();
+
+  const myPubKey = getContext<{ getMyPubKey: () => AgentPubKey }>("myPubKey").getMyPubKey();
 
   $: if (relayStore.conversations.length > 0) {
     goto("/conversations");
@@ -23,7 +23,7 @@
 
 <Header>
   <button on:click={() => goto("/account")}>
-    <Avatar size={24} agentPubKey={relayClient.myPubKey} />
+    <Avatar size={24} agentPubKey={myPubKey} />
   </button>
 
   <button on:click={() => goto("/create")} class="absolute right-4">

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -441,7 +441,7 @@ export function createConversationStore(
     if (message.hash.startsWith("uhCkk")) {
       // don't add placeholder to bucket yet.
       history.add(message);
-      if (!get(isOpen) && message.authorKey !== client.myPubKeyB64) {
+      if (!get(isOpen) && message.authorKey !== encodeHashToBase64(client.client.myPubKey)) {
         setUnread(true);
       }
     }
@@ -596,8 +596,9 @@ export function createConversationStore(
     // Filter out progenitor, as they are always in the list,
     // use contact data for each agent if it exists locally, otherwise use their profile
     // sort by first name (for now)
+    const myPubKeyB64 = encodeHashToBase64(client.client.myPubKey);
     return keys
-      .filter((k) => k !== client.myPubKeyB64)
+      .filter((k) => k !== myPubKeyB64)
       .map((agentKey) => {
         const agentProfile = joinedAgents[agentKey];
         const contactProfile = relayStore.contacts.find((c) => get(c).publicKeyB64 === agentKey);

--- a/ui/src/store/RelayClient.ts
+++ b/ui/src/store/RelayClient.ts
@@ -33,20 +33,13 @@ import { makeFullName } from "$lib/utils";
 export class RelayClient {
   // conversations is a map of string to ClonedCell
   conversations: { [dnaHashB64: DnaHashB64]: ConversationCellAndConfig } = {};
-  myPubKeyB64: AgentPubKeyB64;
 
   constructor(
     public client: AppClient,
     public profilesStore: ProfilesStore,
     public roleName: string,
     public zomeName: string,
-  ) {
-    this.myPubKeyB64 = encodeHashToBase64(this.client.myPubKey);
-  }
-
-  get myPubKey(): AgentPubKey {
-    return this.client.myPubKey;
-  }
+  ) {}
 
   async createProfile(firstName: string, lastName: string, avatar: string): Promise<Record> {
     return this.client.callZome({

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -46,6 +46,8 @@ export class RelayStore {
 
     await this.fetchAllContacts();
 
+    const myPubKeyB64 = encodeHashToBase64(this.client.client.myPubKey);
+
     this.client.client.on("signal", async (signal: Signal) => {
       if (!(SignalType.App in signal)) return;
 
@@ -72,7 +74,7 @@ export class RelayStore {
           timestamp: new Date(payload.action.hashed.content.timestamp / 1000),
         };
 
-        if (conversation && message.authorKey !== this.client.myPubKeyB64) {
+        if (conversation && message.authorKey !== myPubKeyB64) {
           const sender = conversation
             .getAllMembers()
             .find((m) => m.publicKeyB64 == message.authorKey);


### PR DESCRIPTION
Extracted from #279 

- make `myPubKey` and `myPubKeyB64` available as svelte context
- remove `RelayClient` as svelte context
- Avoid using `RelayClient` directly in stores -- currently still used in a few places, which will be addressed in subsequent refactoring.