### PR TITLE
Refactor/use dna types for contacts

### DIFF
--- a/ui/src/lib/ConversationSummary.svelte
+++ b/ui/src/lib/ConversationSummary.svelte
@@ -22,7 +22,7 @@
     : null;
 
   let allMembers = conversationStore.getAllMembers();
-  let joinedMembers = conversationStore.getMemberList();
+  let joinedMembers = conversationStore.getJoinedMembers();
 
   const tAny = t as any;
 

--- a/ui/src/routes/contacts/ContactEditor.svelte
+++ b/ui/src/routes/contacts/ContactEditor.svelte
@@ -27,10 +27,10 @@
   export let creating = false;
 
   let contact = agentPubKeyB64 ? relayStore.getContact(agentPubKeyB64) : undefined;
-  let firstName = $contact?.firstName || "";
-  let lastName = $contact?.lastName || "";
+  let firstName = $contact?.contact.first_name || "";
+  let lastName = $contact?.contact.last_name || "";
   let publicKeyB64 = agentPubKeyB64 || "";
-  let imageUrl = $contact?.avatar || "";
+  let imageUrl = $contact?.contact.avatar || "";
 
   let editing = !agentPubKeyB64 || creating;
   let pendingSave = false;
@@ -76,7 +76,7 @@
       const newContact = $contact
         ? await relayStore.updateContact({
             original_contact_hash: $contact.originalActionHash,
-            previous_contact_hash: $contact.currentActionHash,
+            previous_contact_hash: $contact.previousActionHash,
             updated_contact: newContactData,
           })
         : await relayStore.createContact(newContactData);
@@ -103,9 +103,9 @@
   }
 
   function cancel() {
-    imageUrl = $contact?.avatar || "";
-    firstName = $contact?.firstName || "";
-    lastName = $contact?.lastName || "";
+    imageUrl = $contact?.contact.avatar || "";
+    firstName = $contact?.contact.first_name || "";
+    lastName = $contact?.contact.last_name || "";
 
     if (!agentPubKeyB64 || creating) {
       history.back();
@@ -210,7 +210,7 @@
   {:else}
     <div class="flex flex-1 flex-col items-center">
       <div class="flex flex-row justify-center">
-        <h1 class="mr-2 flex-shrink-0 text-3xl">{$contact?.name}</h1>
+        <h1 class="mr-2 flex-shrink-0 text-3xl">{$contact?.fullName}</h1>
 
         <button on:click={() => (editing = true)}>
           <SvgIcon icon="write" size={24} color="gray" moreClasses="cursor-pointer" />
@@ -238,7 +238,7 @@
         </h1>
         <p class="text-secondary-400 dark:text-tertiary-700 mb-6 mt-4 text-center text-sm">
           {$tAny("contacts.pending_connection_description", {
-            name: $contact?.firstName,
+            name: $contact?.contact.first_name,
           })}
         </p>
         {#if $contact}

--- a/ui/src/routes/contacts/ContactEditor.svelte
+++ b/ui/src/routes/contacts/ContactEditor.svelte
@@ -70,11 +70,15 @@
       const newContactData = {
         avatar: imageUrl,
         first_name: firstName,
-        last_lame: lastName,
+        last_name: lastName,
         public_key: decodeHashFromBase64(publicKeyB64),
       };
       const newContact = $contact
-        ? await relayStore.updateContact({ ...$contact, ...newContactData })
+        ? await relayStore.updateContact({
+            original_contact_hash: $contact.originalActionHash,
+            previous_contact_hash: $contact.currentActionHash,
+            updated_contact: newContactData,
+          })
         : await relayStore.createContact(newContactData);
       if (newContact) {
         if (!agentPubKeyB64) {

--- a/ui/src/routes/contacts/ContactEditor.svelte
+++ b/ui/src/routes/contacts/ContactEditor.svelte
@@ -69,9 +69,9 @@
     try {
       const newContactData = {
         avatar: imageUrl,
-        firstName,
-        lastName,
-        publicKeyB64,
+        first_name: firstName,
+        last_lame: lastName,
+        public_key: decodeHashFromBase64(publicKeyB64),
       };
       const newContact = $contact
         ? await relayStore.updateContact({ ...$contact, ...newContactData })

--- a/ui/src/routes/conversations/[id]/ConversationMembers.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationMembers.svelte
@@ -5,11 +5,11 @@
   export let conversationStore: ConversationStore;
 </script>
 
-{#each conversationStore.getAllMembers().slice(0, 2) as contact, i}
-  {#if contact}
+{#each conversationStore.getAllMembers().slice(0, 2) as profile, i}
+  {#if profile}
     <Avatar
-      image={contact.avatar}
-      agentPubKey={contact.publicKeyB64}
+      image={profile.profile.fields.avatar}
+      agentPubKey={profile.publicKeyB64}
       size={120}
       moreClasses="mb-5"
     />

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -73,11 +73,11 @@
   >
     {#if $conversationStore.conversation.privacy === Privacy.Private}
       <div class="flex items-center justify-center gap-4">
-        {#each conversationStore.getAllMembers().slice(0, 2) as contact, i}
-          {#if contact}
+        {#each conversationStore.getAllMembers().slice(0, 2) as profile}
+          {#if profile}
             <Avatar
-              image={contact.avatar}
-              agentPubKey={contact.publicKeyB64}
+              image={profile.profile.fields.avatar}
+              agentPubKey={profile.publicKeyB64}
               size={120}
               moreClasses="mb-5"
             />
@@ -165,22 +165,20 @@
             />
           </li>
         {:else}
-          {#if conversationStore.getInvitedUnjoined().length > 0}
+          {#if conversationStore.getInvitedUnjoinedContacts().length > 0}
             <h3 class="text-md text-secondary-300 mb-2 font-light">
               {$t("conversations.unconfirmed_invitations")}
             </h3>
 
-            {#each conversationStore.getInvitedUnjoined() as contact}
+            {#each conversationStore.getInvitedUnjoinedContacts() as contact}
               <li class="mb-4 flex flex-row items-center px-2 text-xl">
                 <Avatar
-                  image={contact.avatar}
+                  image={contact.contact.avatar}
                   agentPubKey={contact.publicKeyB64}
                   size={38}
                   moreClasses="-ml-30"
                 />
-                <span class="ml-4 flex-1 text-sm"
-                  >{makeFullName(contact.firstName || "", contact.lastName)}</span
-                >
+                <span class="ml-4 flex-1 text-sm">{contact.fullName}</span>
                 {#await conversationStore.makeInviteCodeForAgent(contact.publicKeyB64) then res}
                   <ButtonsCopyShare
                     text={res}
@@ -204,18 +202,16 @@
             <span class="text-secondary-300 ml-2 text-xs">{$t("conversations.admin")}</span>
           {/if}
         </li>
-        {#each conversationStore.getMemberList() as contact}
+        {#each conversationStore.getMemberList() as profile}
           <li class="mb-4 flex flex-row items-center px-2 text-xl">
             <Avatar
-              image={contact.avatar}
-              agentPubKey={contact.publicKeyB64}
+              image={profile.profile.fields.avatar}
+              agentPubKey={profile.publicKeyB64}
               size={38}
               moreClasses="-ml-30"
             />
-            <span class="ml-4 flex-1 text-sm font-bold"
-              >{makeFullName(contact.firstName, contact.lastName)}</span
-            >
-            {#if contact.publicKeyB64 === encodeHashToBase64($conversationStore.conversation.progenitor)}
+            <span class="ml-4 flex-1 text-sm font-bold">{profile.profile.nickname}</span>
+            {#if profile.publicKeyB64 === encodeHashToBase64($conversationStore.conversation.progenitor)}
               <span class="text-secondary-300 ml-2 text-xs">{$t("conversations.admin")}</span>
             {/if}
           </li>

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -201,7 +201,7 @@
             <span class="text-secondary-300 ml-2 text-xs">{$t("conversations.admin")}</span>
           {/if}
         </li>
-        {#each conversationStore.getMemberList() as profile}
+        {#each conversationStore.getJoinedMembers() as profile}
           <li class="mb-4 flex flex-row items-center px-2 text-xl">
             <Avatar
               image={profile.profile.fields.avatar}

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -13,7 +13,6 @@
   import HiddenFileInput from "$lib/HiddenFileInput.svelte";
   import ButtonsCopyShare from "$lib/ButtonsCopyShare.svelte";
   import TitleInput from "./TitleInput.svelte";
-  import { makeFullName } from "$lib/utils";
 
   // Silly hack to get around issues with typescript in sveltekit-i18n
   const tAny = t as any;

--- a/ui/src/routes/conversations/[id]/invite/+page.svelte
+++ b/ui/src/routes/conversations/[id]/invite/+page.svelte
@@ -113,7 +113,7 @@
           )}
           {@const alreadyInConversation = conversationStore
             ? !!conversationStore
-                .getMemberList()
+                .getJoinedMembers()
                 .find((m) => m?.publicKeyB64 === contact.publicKeyB64)
             : false}
           <button

--- a/ui/src/routes/conversations/[id]/invite/+page.svelte
+++ b/ui/src/routes/conversations/[id]/invite/+page.svelte
@@ -9,7 +9,6 @@
   import SvgIcon from "$lib/SvgIcon.svelte";
   import { t } from "$translations";
   import { RelayStore } from "$store/RelayStore";
-  import { makeFullName } from "$lib/utils";
   import { Privacy } from "../../../../types";
   import toast from "svelte-french-toast";
   import type { AgentPubKeyB64 } from "@holochain/client";
@@ -29,11 +28,11 @@
     return $contacts
       .filter(
         (c) =>
-          c.firstName.toLowerCase().includes(test) ||
-          c.lastName.toLowerCase().includes(test) ||
+          c.contact.first_name.toLowerCase().includes(test) ||
+          c.contact.first_name.toLowerCase().includes(test) ||
           (test.length > 2 && c.publicKeyB64.toLowerCase().includes(test)),
       )
-      .sort((a, b) => a.firstName.localeCompare(b.firstName));
+      .sort((a, b) => a.contact.first_name.localeCompare(b.contact.first_name));
   });
 
   function selectContact(publicKeyB64: string) {
@@ -101,11 +100,11 @@
     {:else}
       <div class="w-full font-light">
         {#each $contacts as contact, i}
-          {#if i === 0 || contact.firstName.charAt(0).toUpperCase() !== $contacts[i - 1].firstName
-                .charAt(0)
-                .toUpperCase()}
+          {#if i === 0 || contact.contact.first_name
+              .charAt(0)
+              .toUpperCase() !== $contacts[i - 1].contact.first_name.charAt(0).toUpperCase()}
             <p class="text-secondary-300 mb-1 mt-2 pl-0">
-              {contact.firstName[0].toUpperCase()}
+              {contact.contact.first_name[0].toUpperCase()}
             </p>
           {/if}
           {@const selected = selectedContacts.find((c) => c === contact.publicKeyB64)}
@@ -125,12 +124,12 @@
           >
             <Avatar
               size={38}
-              image={contact.avatar}
+              image={contact.contact.avatar}
               agentPubKey={contact.publicKeyB64}
               moreClasses="mr-3"
             />
             <p class="text-secondary-500 dark:text-tertiary-100 flex-1 text-start">
-              {makeFullName(contact.firstName, contact.lastName)}
+              {contact.fullName}
             </p>
             {#if alreadyInConversation}
               <span class="text-xs font-extralight">{$t("conversations.already_member")}</span>
@@ -160,7 +159,10 @@
             </div>
             <div class="pb-1 text-start text-xs font-light">
               with {selectedContacts
-                .map((c) => $contacts.find((contact) => c === contact.publicKeyB64)?.firstName)
+                .map(
+                  (c) =>
+                    $contacts.find((contact) => c === contact.publicKeyB64)?.contact.first_name,
+                )
                 .join(", ")}
             </div>
           </div>

--- a/ui/src/routes/create/+page.svelte
+++ b/ui/src/routes/create/+page.svelte
@@ -9,7 +9,6 @@
   import { t } from "$translations";
   import { RelayStore } from "$store/RelayStore";
   import { Privacy } from "../../types";
-  import { makeFullName } from "$lib/utils";
   import type { AgentPubKeyB64 } from "@holochain/client";
   import { xor } from "lodash-es";
 
@@ -26,7 +25,7 @@
     .map((s) => relayStore.contacts.find((c) => s === get(c).publicKeyB64))
     .filter((c) => c !== undefined);
 
-  $: selectedContactsNames = selectedContactStores.map((c) => get(c).firstName).join(", ");
+  $: selectedContactsNames = selectedContactStores.map((c) => get(c).contact.first_name).join(", ");
 
   $: existingConversationStore =
     selectedContacts.length === 0
@@ -50,11 +49,11 @@
     return $contacts
       .filter(
         (c) =>
-          c.firstName.toLowerCase().includes(test) ||
-          c.lastName.toLowerCase().includes(test) ||
+          c.contact.first_name.toLowerCase().includes(test) ||
+          c.contact.first_name.toLowerCase().includes(test) ||
           (test.length > 2 && c.publicKeyB64.toLowerCase().includes(test)),
       )
-      .sort((a, b) => a.firstName.localeCompare(b.firstName))
+      .sort((a, b) => a.contact.first_name.localeCompare(b.contact.first_name))
       .map((c) => c.publicKeyB64);
   });
 
@@ -77,11 +76,11 @@
     let title = "";
     if (selectedContactStores.length === 1) {
       const c = get(selectedContactStores[0]);
-      title = makeFullName(c.firstName, c.lastName);
+      title = c.fullName;
     } else if (selectedContacts.length === 2) {
-      title = selectedContactStores.map((c) => get(c).firstName).join(" & ");
+      title = selectedContactStores.map((c) => get(c).contact.first_name).join(" & ");
     } else if (selectedContacts.length > 2) {
-      title = selectedContactStores.map((c) => get(c).firstName).join(", ");
+      title = selectedContactStores.map((c) => get(c).contact.first_name).join(", ");
     }
 
     const conversationStore = await relayStore.createConversation(
@@ -177,11 +176,11 @@
         {@const selected = selectedContacts.includes(contact.publicKeyB64)}
         {@const prevContact = i === 0 ? undefined : get(contactsFilteredStores[i - 1])}
 
-        {#if prevContact === undefined || contact.firstName
+        {#if prevContact === undefined || contact.contact.first_name
             .charAt(0)
-            .toUpperCase() !== prevContact?.firstName.charAt(0).toUpperCase()}
+            .toUpperCase() !== prevContact?.contact.first_name.charAt(0).toUpperCase()}
           <p class="text-secondary-300 mb-1 mt-2 pl-0">
-            {contact.firstName[0].toUpperCase()}
+            {contact.contact.first_name[0].toUpperCase()}
           </p>
         {/if}
 
@@ -192,7 +191,7 @@
         >
           <Avatar
             size={38}
-            image={contact.avatar}
+            image={contact.contact.avatar}
             agentPubKey={contact.publicKeyB64}
             moreClasses="mr-3"
           />
@@ -201,7 +200,7 @@
               ? 'text-secondary-400 dark:!text-secondary-300'
               : ''}"
           >
-            {makeFullName(contact.firstName, contact.lastName)}
+            {contact.fullName}
             {#if contactStore.getIsPendingConnection()}<span class="text-secondary-400 ml-1 text-xs"
                 >{$t("create.unconfirmed")}</span
               >{/if}

--- a/ui/src/store/ContactStore.ts
+++ b/ui/src/store/ContactStore.ts
@@ -14,6 +14,17 @@ import type { Contact, ContactExtended } from "../types";
 export interface ContactStore {
   getPrivateConversation: () => ConversationStore | undefined;
   getIsPendingConnection: () => boolean | undefined;
+  getAsProfile: () => {
+    publicKeyB64: string;
+    profile: {
+      nickname: string;
+      fields: {
+        firstName: string;
+        lastName: string;
+        avatar: string;
+      };
+    };
+  };
   subscribe: (
     this: void,
     run: Subscriber<ContactExtended>,
@@ -33,7 +44,7 @@ export function createContactStore(
     `CONTACTS.${publicKeyB64}.PRIVATE_CONVERSATION`,
     dnaHashB64,
   );
-  const { subscribe } = writable<ContactExtended>({
+  const data = writable<ContactExtended>({
     contact,
     originalActionHash,
     previousActionHash,
@@ -58,9 +69,26 @@ export function createContactStore(
     return conversationAgents && Object.keys(conversationAgents).length === 1;
   }
 
+  function getAsProfile() {
+    const val = get(data);
+
+    return {
+      publicKeyB64: val.publicKeyB64,
+      profile: {
+        nickname: val.fullName,
+        fields: {
+          firstName: val.contact.first_name,
+          lastName: val.contact.last_name,
+          avatar: val.contact.avatar,
+        },
+      },
+    };
+  }
+
   return {
     getPrivateConversation,
     getIsPendingConnection,
-    subscribe,
+    getAsProfile,
+    subscribe: data.subscribe,
   };
 }

--- a/ui/src/store/ContactStore.ts
+++ b/ui/src/store/ContactStore.ts
@@ -11,7 +11,7 @@ import { RelayStore } from "$store/RelayStore";
 import { makeFullName } from "$lib/utils";
 import { persisted } from "svelte-persisted-store";
 import type { ConversationStore } from "./ConversationStore";
-import type { Contact, ContactExtended } from "../types";
+import type { ContactExtended } from "../types";
 
 export interface ContactStore {
   getPrivateConversation: () => ConversationStore | undefined;
@@ -37,18 +37,18 @@ export function createContactStore(
     `CONTACTS.${publicKeyB64}.PRIVATE_CONVERSATION`,
     dnaHashB64,
   );
-  const contact = writable<Contact>({
-    avatar,
+  const contact = writable<ContactExtended>({
     currentActionHash,
+    originalActionHash,
     firstName,
     lastName,
-    originalActionHash,
+    name: makeFullName(firstName, lastName),
+    avatar,
     publicKeyB64,
     privateConversationDnaHashB64: get(privateConversationDnaHashB64),
   });
   const { subscribe } = derived<typeof contact, ContactExtended>(contact, ($contact) => ({
     ...$contact,
-    name: makeFullName($contact.firstName, $contact.lastName),
   }));
 
   function getPrivateConversation() {

--- a/ui/src/store/ContactStore.ts
+++ b/ui/src/store/ContactStore.ts
@@ -26,10 +26,10 @@ export interface ContactStore {
 export function createContactStore(
   relayStore: RelayStore,
   avatar: string,
-  currentActionHash: ActionHash | undefined,
+  currentActionHash: ActionHash,
   firstName: string,
   lastName: string,
-  originalActionHash: ActionHash | undefined,
+  originalActionHash: ActionHash,
   publicKeyB64: AgentPubKeyB64,
   dnaHashB64?: DnaHashB64 | undefined,
 ) {

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -73,7 +73,7 @@ export interface ConversationStore {
   setUnread: (unread: boolean) => void;
   makeInviteCodeForAgent: (publicKeyB64: string) => Promise<string>;
   getAllMembers: () => ProfileExtended[];
-  getMemberList: (includeInvited?: boolean) => ProfileExtended[];
+  getJoinedMembers: () => ProfileExtended[];
   getInvitedUnjoinedContacts: () => ContactExtended[];
   getTitle: () => string;
   subscribe: (
@@ -564,10 +564,14 @@ export function createConversationStore(
   }
 
   function getAllMembers(): ProfileExtended[] {
-    return getMemberList(true);
+    return _getMembers(true);
   }
 
-  function getMemberList(includeInvited = false): ProfileExtended[] {
+  function getJoinedMembers(): ProfileExtended[] {
+    return _getMembers(false);
+  }
+
+  function _getMembers(includeInvited: boolean): ProfileExtended[] {
     // return the list of agents that have joined the conversation, checking the relayStore for contacts and using the contact info first and if that doesn't exist using the agent profile
     const joinedAgents = get(conversation).agentProfiles;
 
@@ -648,7 +652,7 @@ export function createConversationStore(
 
     // get filtered data
     getAllMembers,
-    getMemberList,
+    getJoinedMembers,
     getInvitedUnjoinedContacts,
     getTitle,
 

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -23,6 +23,7 @@ import { v4 as uuidv4 } from "uuid";
 import { RelayStore } from "$store/RelayStore";
 import {
   type Config,
+  type ContactExtended,
   type Conversation,
   type Image,
   type Invitation,
@@ -30,6 +31,8 @@ import {
   type Message,
   type MessageRecord,
   Privacy,
+  type Profile,
+  type ProfileExtended,
 } from "../types";
 import { createMessageHistoryStore } from "./MessageHistoryStore";
 import pRetry from "p-retry";
@@ -37,7 +40,6 @@ import { fileToDataUrl, makeFullName } from "$lib/utils";
 import { BUCKET_RANGE_MS, TARGET_MESSAGES_COUNT } from "$config";
 import { page } from "$app/stores";
 import { persisted } from "svelte-persisted-store";
-import type { Profile } from "@holochain-open-dev/profiles";
 
 export interface ConversationStoreData {
   conversation: Conversation;
@@ -70,24 +72,9 @@ export interface ConversationStore {
   toggleArchived: () => void;
   setUnread: (unread: boolean) => void;
   makeInviteCodeForAgent: (publicKeyB64: string) => Promise<string>;
-  getAllMembers: () => {
-    publicKeyB64: string;
-    avatar: string;
-    firstName: string;
-    lastName: string;
-  }[];
-  getMemberList: (includeInvited?: boolean) => {
-    publicKeyB64: string;
-    avatar: string;
-    firstName: string;
-    lastName: string;
-  }[];
-  getInvitedUnjoined: () => {
-    publicKeyB64: string;
-    avatar: string;
-    firstName: string;
-    lastName: string;
-  }[];
+  getAllMembers: () => ProfileExtended[];
+  getMemberList: (includeInvited?: boolean) => ProfileExtended[];
+  getInvitedUnjoinedContacts: () => ContactExtended[];
   getTitle: () => string;
   subscribe: (
     this: void,
@@ -166,10 +153,10 @@ export function createConversationStore(
       const displayMessage = {
         ...message,
         author: contact
-          ? get(contact).firstName
+          ? get(contact).contact.first_name
           : $conversation.agentProfiles[message.authorKey].fields.firstName,
         avatar: contact
-          ? get(contact).avatar
+          ? get(contact).contact.avatar
           : $conversation.agentProfiles[message.authorKey].fields.avatar,
       };
 
@@ -563,29 +550,24 @@ export function createConversationStore(
     return Base64.fromUint8Array(msgpck);
   }
 
-  function getInvitedUnjoined() {
+  function getInvitedUnjoinedContacts(): ContactExtended[] {
     const joinedAgents = get(conversation).agentProfiles;
     return get(localData)
       .invitedContactKeys.filter((contactKey) => !joinedAgents[contactKey]) // filter out already joined agents
       .map((contactKey) => {
         const contactProfile = relayStore.contacts.find((c) => get(c).publicKeyB64 === contactKey);
         if (!contactProfile) return;
-        const c = get(contactProfile);
-        return {
-          publicKeyB64: contactKey,
-          avatar: c.avatar,
-          firstName: c.firstName,
-          lastName: c.lastName,
-        };
+
+        return get(contactProfile);
       })
       .filter((c) => c !== undefined);
   }
 
-  function getAllMembers() {
+  function getAllMembers(): ProfileExtended[] {
     return getMemberList(true);
   }
 
-  function getMemberList(includeInvited = false) {
+  function getMemberList(includeInvited = false): ProfileExtended[] {
     // return the list of agents that have joined the conversation, checking the relayStore for contacts and using the contact info first and if that doesn't exist using the agent profile
     const joinedAgents = get(conversation).agentProfiles;
 
@@ -604,23 +586,15 @@ export function createConversationStore(
         const contactProfile = relayStore.contacts.find((c) => get(c).publicKeyB64 === agentKey);
 
         if (contactProfile) {
-          const c = get(contactProfile);
-          return {
-            publicKeyB64: agentKey,
-            avatar: c.avatar,
-            firstName: c.firstName,
-            lastName: c.lastName,
-          };
+          return contactProfile.getAsProfile();
         } else {
           return {
+            profile: agentProfile,
             publicKeyB64: agentKey,
-            avatar: agentProfile?.fields.avatar,
-            firstName: agentProfile?.fields.firstName,
-            lastName: agentProfile?.fields.lastName, // if any contact profile exists use that data
           };
         }
       })
-      .sort((a, b) => a.firstName.localeCompare(b.firstName));
+      .sort((a, b) => a.profile.nickname.localeCompare(b.profile.nickname));
   }
 
   function getTitle() {
@@ -635,13 +609,11 @@ export function createConversationStore(
       return c.config.title;
     } else if (allMembers.length === 1) {
       // Use full name of the one other person in the chat
-      return getAllMembers()[0]
-        ? makeFullName(allMembers[0].firstName, allMembers[0].lastName)
-        : c.config.title;
+      return getAllMembers()[0] ? allMembers[0].profile.nickname : c.config.title;
     } else if (allMembers.length === 2) {
-      return allMembers.map((m) => m?.firstName).join(" & ");
+      return allMembers.map((m) => m?.profile.fields.firstName).join(" & ");
     } else {
-      return allMembers.map((m) => m?.firstName).join(", ");
+      return allMembers.map((m) => m?.profile.fields.firstName).join(", ");
     }
   }
 
@@ -677,7 +649,7 @@ export function createConversationStore(
     // get filtered data
     getAllMembers,
     getMemberList,
-    getInvitedUnjoined,
+    getInvitedUnjoinedContacts,
     getTitle,
 
     subscribe,

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -36,7 +36,7 @@ import {
 } from "../types";
 import { createMessageHistoryStore } from "./MessageHistoryStore";
 import pRetry from "p-retry";
-import { fileToDataUrl, makeFullName } from "$lib/utils";
+import { fileToDataUrl } from "$lib/utils";
 import { BUCKET_RANGE_MS, TARGET_MESSAGES_COUNT } from "$config";
 import { page } from "$app/stores";
 import { persisted } from "svelte-persisted-store";

--- a/ui/src/store/RelayClient.ts
+++ b/ui/src/store/RelayClient.ts
@@ -27,6 +27,7 @@ import type {
   Message,
   MessageRecord,
   Privacy,
+  UpdateContactInput,
 } from "../types";
 import { makeFullName } from "$lib/utils";
 
@@ -327,35 +328,21 @@ export class RelayClient {
     });
   }
 
-  public async createContact(contact: Contact): Promise<Record> {
+  public async createContact(payload: Contact): Promise<Record> {
     return this.client.callZome({
       role_name: this.roleName,
       zome_name: this.zomeName,
       fn_name: "create_contact",
-      payload: {
-        avatar: contact.avatar,
-        first_name: contact.firstName,
-        last_name: contact.lastName,
-        public_key: decodeHashFromBase64(contact.publicKeyB64),
-      },
+      payload,
     });
   }
 
-  public async updateContact(contact: Contact): Promise<Record> {
+  public async updateContact(payload: UpdateContactInput): Promise<Record> {
     return this.client.callZome({
       role_name: this.roleName,
       zome_name: this.zomeName,
       fn_name: "update_contact",
-      payload: {
-        original_contact_hash: contact.originalActionHash,
-        previous_contact_hash: contact.currentActionHash,
-        updated_contact: {
-          avatar: contact.avatar,
-          first_name: contact.firstName,
-          last_name: contact.lastName,
-          public_key: decodeHashFromBase64(contact.publicKeyB64),
-        },
-      },
+      payload,
     });
   }
 }

--- a/ui/src/store/RelayClient.ts
+++ b/ui/src/store/RelayClient.ts
@@ -14,7 +14,7 @@ import {
   type Record,
 } from "@holochain/client";
 import { EntryRecord } from "@holochain-open-dev/utils";
-import type { Profile, ProfilesStore } from "@holochain-open-dev/profiles";
+import type { ProfilesStore } from "@holochain-open-dev/profiles";
 import { get } from "svelte/store";
 import type {
   Config,
@@ -28,6 +28,7 @@ import type {
   MessageRecord,
   Privacy,
   UpdateContactInput,
+  Profile,
 } from "../types";
 import { makeFullName } from "$lib/utils";
 

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -166,15 +166,11 @@ export class RelayStore {
   async fetchAllContacts() {
     const contactRecords = await this.client.getAllContacts();
     this.contacts = contactRecords.map((contactRecord: any) => {
-      const contact = contactRecord.contact;
       return createContactStore(
         this,
-        contact.avatar,
-        contactRecord.signed_action.hashed.hash,
-        contact.first_name,
-        contact.last_name,
+        contactRecord.contact,
         contactRecord.original_action,
-        encodeHashToBase64(contact.public_key),
+        contactRecord.signed_action.hashed.hash,
       );
     });
   }
@@ -202,12 +198,9 @@ export class RelayStore {
       }
       const contactStore = createContactStore(
         this,
-        contact.avatar,
+        contact,
         contactResult.signed_action.hashed.hash,
-        contact.first_name,
-        contact.last_name,
         contactResult.signed_action.hashed.hash,
-        encodeHashToBase64(contact.public_key),
         conversation ? get(conversation).conversation.dnaHashB64 : undefined,
       );
       this.contacts = [...this.contacts, contactStore];
@@ -223,12 +216,10 @@ export class RelayStore {
     if (contactResult) {
       const contactStore = createContactStore(
         this,
-        input.updated_contact.avatar,
-        contactResult.signed_action.hashed.hash,
-        input.updated_contact.first_name,
-        input.updated_contact.last_name,
+        input.updated_contact,
         input.original_contact_hash,
-        contactPubKeyB64,
+        input.previous_contact_hash,
+        input.updated_contact.avatar,
       );
       this.contacts = [
         ...this.contacts.filter((c) => get(c).publicKeyB64 !== contactPubKeyB64),

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -85,12 +85,12 @@ export class RelayStore {
               message.content.length > 125 ? message.content.slice(0, 50) + "..." : message.content;
             if (isMobile()) {
               enqueueNotification(
-                `${sender ? makeFullName(sender.firstName, sender.lastName) : message.authorKey}: ${msgShort}`,
+                `${sender ? sender.profile.nickname : message.authorKey}: ${msgShort}`,
                 message.content,
               );
             } else {
               enqueueNotification(
-                `Message from ${sender ? makeFullName(sender.firstName, sender.lastName) : message.authorKey}`,
+                `Message from ${sender ? sender.profile.nickname : message.authorKey}`,
                 message.content,
               );
             }

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -21,6 +21,7 @@ import type {
   Message,
   Properties,
   RelaySignal,
+  UpdateContactInput,
 } from "../types";
 import { Privacy } from "../types";
 import { enqueueNotification, isMobile, makeFullName } from "$lib/utils";
@@ -214,21 +215,23 @@ export class RelayStore {
     }
   }
 
-  async updateContact(contact: Contact) {
+  async updateContact(input: UpdateContactInput) {
     if (!this.client) return false;
-    const contactResult = await this.client.updateContact(contact);
+    const contactResult = await this.client.updateContact(input);
+    const contactPubKeyB64 = encodeHashToBase64(input.updated_contact.public_key);
+
     if (contactResult) {
       const contactStore = createContactStore(
         this,
-        contact.avatar,
+        input.updated_contact.avatar,
         contactResult.signed_action.hashed.hash,
-        contact.firstName,
-        contact.lastName,
-        contact.originalActionHash,
-        contact.publicKeyB64,
+        input.updated_contact.first_name,
+        input.updated_contact.last_name,
+        input.original_contact_hash,
+        contactPubKeyB64,
       );
       this.contacts = [
-        ...this.contacts.filter((c) => get(c).publicKeyB64 !== contact.publicKeyB64),
+        ...this.contacts.filter((c) => get(c).publicKeyB64 !== contactPubKeyB64),
         contactStore,
       ];
       return contactStore;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -65,17 +65,6 @@ export interface Properties {
 
 export type EntryTypes = { type: "Message" } & MessageInput;
 
-export interface ContactExtended {
-  currentActionHash: ActionHash;
-  originalActionHash: ActionHash;
-  avatar: string;
-  privateConversationDnaHashB64?: DnaHashB64;
-  firstName: string;
-  lastName: string;
-  name: string;
-  publicKeyB64: AgentPubKeyB64;
-}
-
 export interface MessageInput {
   content: string;
   bucket: number;
@@ -171,6 +160,10 @@ export interface ConversationCellAndConfig {
   config: Config;
 }
 
+/**
+ * Contact
+ */
+
 export interface Contact {
   public_key: AgentPubKey;
   first_name: string;
@@ -188,4 +181,13 @@ export interface UpdateContactInput {
   original_contact_hash: ActionHash;
   previous_contact_hash: ActionHash;
   updated_contact: Contact;
+}
+
+export interface ContactExtended {
+  contact: Contact;
+  fullName: string; // Full name
+  publicKeyB64: AgentPubKeyB64;
+  originalActionHash: ActionHash;
+  previousActionHash: ActionHash;
+  privateConversationDnaHashB64?: DnaHashB64;
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -66,8 +66,8 @@ export interface Properties {
 export type EntryTypes = { type: "Message" } & MessageInput;
 
 export interface ContactExtended {
-  currentActionHash?: ActionHash;
-  originalActionHash?: ActionHash;
+  currentActionHash: ActionHash;
+  originalActionHash: ActionHash;
   avatar: string;
   privateConversationDnaHashB64?: DnaHashB64;
   firstName: string;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -65,16 +65,6 @@ export interface Properties {
 
 export type EntryTypes = { type: "Message" } & MessageInput;
 
-export interface Contact {
-  currentActionHash?: ActionHash;
-  originalActionHash?: ActionHash;
-  avatar: string;
-  privateConversationDnaHashB64?: DnaHashB64;
-  firstName: string;
-  lastName: string;
-  publicKeyB64: AgentPubKeyB64;
-}
-
 export interface ContactExtended {
   currentActionHash?: ActionHash;
   originalActionHash?: ActionHash;
@@ -181,8 +171,21 @@ export interface ConversationCellAndConfig {
   config: Config;
 }
 
+export interface Contact {
+  public_key: AgentPubKey;
+  first_name: string;
+  last_name: string;
+  avatar: string;
+}
+
 export interface ContactRecord {
   original_action: ActionHash;
   signed_action: SignedActionHashed;
   contact?: Contact;
+}
+
+export interface UpdateContactInput {
+  original_contact_hash: ActionHash;
+  previous_contact_hash: ActionHash;
+  updated_contact: Contact;
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -15,8 +15,6 @@ import type {
   DnaHashB64,
 } from "@holochain/client";
 
-import type { Profile } from "@holochain-open-dev/profiles";
-
 export type RelaySignal =
   | {
       type: "Message";
@@ -190,4 +188,15 @@ export interface ContactExtended {
   originalActionHash: ActionHash;
   previousActionHash: ActionHash;
   privateConversationDnaHashB64?: DnaHashB64;
+}
+
+/**
+ * Profiles
+ */
+import type { Profile } from "@holochain-open-dev/profiles";
+export type { Profile } from "@holochain-open-dev/profiles";
+
+export interface ProfileExtended {
+  profile: Profile;
+  publicKeyB64: AgentPubKeyB64;
 }


### PR DESCRIPTION
Extracted from #279 

- Add typescript types matching DNA types for Contact
- Modify ContactExtended type used in UI to have minimal necessary data
- Modify createContactStore inputs to minimal necessary data
- Add ProfileExtended type for use in UI when Profile + agent key is needed
- Use DNA types directly in RelayClient calls
- Re-export Profile from app types, to avoid confusion
- Modify ConversationsStore functions that return list of members
  - Return normalized ProfileExtended types
  - Change function names for clarity
- Delete a whole bunch of no longer necessary `makeFullName` calls, since the full name is included in the Profile (as nickname), and ContactExtended (as fullName)