### PR TITLE
Refactor/relay client functions take cellid

### DIFF
--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -10,3 +10,5 @@ export const TARGET_MESSAGES_COUNT = 20;
 // Minimum length of profile first name
 // This is not enforced by DNA validation, so is only softly required in the frontend.
 export const MIN_FIRST_NAME_LENGTH = 3;
+
+export const DEFAULT_CONVERSATION_CONFIG = { title: "", image: "" };

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -9,6 +9,7 @@ import {
   type Signal,
   SignalType,
   type DnaHashB64,
+  type ClonedCell,
 } from "@holochain/client";
 import { type ContactStore, createContactStore } from "./ContactStore";
 import { type ConversationStore, createConversationStore } from "./ConversationStore";
@@ -39,11 +40,19 @@ export class RelayStore {
   constructor(public client: RelayClient) {}
 
   async initialize() {
-    await this.client.initConversations();
+    const relayClonedCellInfos = await this.client.getRelayClonedCellInfos();
+    const cellInfoConfigs = (
+      await Promise.allSettled(
+        relayClonedCellInfos.map(async (clonedCellInfo: ClonedCell) => ({
+          cell: clonedCellInfo,
+          config: await this.client.getConfig(clonedCellInfo.cell_id),
+        })),
+      )
+    )
+      .filter((v) => v.status === "fulfilled")
+      .map((v) => v.value);
 
-    for (const conversation of Object.values(this.client.conversations)) {
-      await this._addConversation(conversation);
-    }
+    await Promise.allSettled(cellInfoConfigs.map(async (c) => this._addConversation(c)));
 
     await this.fetchAllContacts();
 

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -153,11 +153,6 @@ export class RelayStore {
     return null;
   }
 
-  async inviteAgentToConversation(dnaHashB64: DnaHashB64, agent: AgentPubKey, role: number = 0) {
-    if (!this.client) return;
-    return await this.client.inviteAgentToConversation(dnaHashB64, agent, role);
-  }
-
   getConversation(dnaHashB64: DnaHashB64): ConversationStore | undefined {
     return this.conversations.find((c) => get(c).conversation.dnaHashB64 === dnaHashB64);
   }


### PR DESCRIPTION
Extracted from #279 

- All RelayClient calls take a CellId, not a DnaHashB64
- Avoid storing conversations cell's CellInfo and Config in RelayClient, instead call `appInfo`, or move logic to parent
- Delete unused relayStore function