### PR TITLE
Refactor/conversation cloning

### DIFF
--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -10,5 +10,3 @@ export const TARGET_MESSAGES_COUNT = 20;
 // Minimum length of profile first name
 // This is not enforced by DNA validation, so is only softly required in the frontend.
 export const MIN_FIRST_NAME_LENGTH = 3;
-
-export const DEFAULT_CONVERSATION_CONFIG = { title: "", image: "" };

--- a/ui/src/lib/ButtonsCopyShare.svelte
+++ b/ui/src/lib/ButtonsCopyShare.svelte
@@ -19,13 +19,11 @@
   }
 
   async function share() {
-    async () => {
-      try {
-        await shareText(text);
-      } catch (e) {
-        toast.error(`${$t("common.share_code_error")}: ${e.message}`);
-      }
-    };
+    try {
+      await shareText(text);
+    } catch (e) {
+      toast.error(`${$t("common.share_code_error")}: ${e.message}`);
+    }
   }
 </script>
 

--- a/ui/src/lib/ConversationSummary.svelte
+++ b/ui/src/lib/ConversationSummary.svelte
@@ -166,32 +166,32 @@
             </span>
           {:else if allMembers.length == 1}
             <Avatar
-              image={allMembers[0]?.avatar}
+              image={allMembers[0].profile.fields.avatar}
               agentPubKey={allMembers[0]?.publicKeyB64}
               size={40}
             />
           {:else if allMembers.length == 2}
             <Avatar
-              image={allMembers[0]?.avatar}
+              image={allMembers[0].profile.fields.avatar}
               agentPubKey={allMembers[0]?.publicKeyB64}
               size={22}
               moreClasses=""
             />
             <Avatar
-              image={allMembers[1]?.avatar}
+              image={allMembers[1].profile.fields.avatar}
               agentPubKey={allMembers[1]?.publicKeyB64}
               size={22}
               moreClasses="relative -ml-1"
             />
           {:else}
             <Avatar
-              image={allMembers[0]?.avatar}
+              image={allMembers[0].profile.fields.avatar}
               agentPubKey={allMembers[0]?.publicKeyB64}
               size={22}
               moreClasses="relative -mb-2"
             />
             <Avatar
-              image={allMembers[1]?.avatar}
+              image={allMembers[1].profile.fields.avatar}
               agentPubKey={allMembers[1]?.publicKeyB64}
               size={22}
               moreClasses="relative -ml-3 -mt-3"
@@ -203,7 +203,7 @@
             </div>
           {/if}
         </div>
-      {:else if conversation.config.image}
+      {:else if conversation.config?.image}
         <img
           src={conversation.config.image}
           alt="Conversation"

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -32,7 +32,7 @@
       console.log("__HC_LAUNCHER_ENV__ is", window.__HC_LAUNCHER_ENV__);
 
       // Connect to holochain
-      client = await AppWebsocket.connect({ defaultTimeout: 15000 });
+      client = await AppWebsocket.connect({ defaultTimeout: 30000 });
 
       // Call 'ping' with very long timeout
       // This should be the first zome call after the client connects,

--- a/ui/src/routes/account/+page.svelte
+++ b/ui/src/routes/account/+page.svelte
@@ -37,8 +37,6 @@
   async function saveName(newFirstName: string, newLastName: string) {
     if (newFirstName.length < MIN_FIRST_NAME_LENGTH) return;
 
-    console.log("save", newFirstName, newLastName);
-
     try {
       await relayStore.client.updateProfile(newFirstName, newLastName, avatar);
       firstName = newFirstName;

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -194,7 +194,7 @@
 
           <ConversationMembers {conversationStore} />
         </div>
-      {:else if $conversationStore.conversation.config.image}
+      {:else if $conversationStore.conversation.config?.image}
         <img
           src={$conversationStore.conversation.config.image}
           alt="Conversation"

--- a/ui/src/routes/conversations/[id]/Message.svelte
+++ b/ui/src/routes/conversations/[id]/Message.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import type { RelayStore } from "$store/RelayStore";
   import { getContext } from "svelte";
   import { type Message as MessageType } from "../../../types";
   import Time from "svelte-time";

--- a/ui/src/routes/conversations/[id]/MessageActions.svelte
+++ b/ui/src/routes/conversations/[id]/MessageActions.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { Message, Image } from "../../../types";
   import Button from "$lib/Button.svelte";
-  import SvgIcon from "$lib/SvgIcon.svelte";
   import { t } from "$translations";
   import { convertDataURIToUint8Array, copyToClipboard } from "$lib/utils";
   import { save } from "@tauri-apps/plugin-dialog";

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -26,14 +26,14 @@
   let conversationStore = relayStore.getConversation($page.params.id);
 
   // used for editing Group conversation details
-  let image = $conversationStore?.conversation.config.image;
+  let image = $conversationStore?.conversation.config?.image || "";
   let title = conversationStore?.getTitle() || "";
   let editingTitle = false;
 
   const saveTitle = async (newTitle: string) => {
     if (!conversationStore) return;
 
-    conversationStore.updateConfig({ title: newTitle.trim() });
+    conversationStore.setConfig({ title: newTitle.trim(), image });
     title = newTitle.trim();
     editingTitle = false;
   };
@@ -41,7 +41,10 @@
   const saveImage = async (newImage: string) => {
     if (!conversationStore) return;
 
-    conversationStore.updateConfig({ image: newImage });
+    conversationStore.setConfig({
+      title: $conversationStore?.conversation.config?.title || "",
+      image: newImage,
+    });
     image = newImage;
   };
 </script>

--- a/ui/src/routes/conversations/join/+page.svelte
+++ b/ui/src/routes/conversations/join/+page.svelte
@@ -23,19 +23,14 @@
       const msgpack = Base64.toUint8Array(inviteCode);
       const invitation: Invitation = decode(msgpack) as Invitation;
       const conversationStore = await relayStore.joinConversation(invitation);
-      if (conversationStore) {
-        goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}`);
-        joining = false;
-      } else {
-        console.error("Error joining conversation, couldn't create the conversation");
-        error = true;
-        joining = false;
-      }
+
+      goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}`);
     } catch (e) {
       error = true;
-      joining = false;
       console.error("Error joining conversation", e);
     }
+
+    joining = false;
   }
 </script>
 

--- a/ui/src/routes/conversations/new/+page.svelte
+++ b/ui/src/routes/conversations/new/+page.svelte
@@ -24,13 +24,11 @@
     pendingCreate = true;
     try {
       const conversationStore = await relayStore.createConversation(title, imageUrl, privacy);
-      if (conversationStore) {
-        goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}`);
-        pendingCreate = false;
-      }
+      goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}`);
     } catch (e) {
       toast.error(`${$t("common.create_conversation_error")}: ${e.message}`);
     }
+    pendingCreate = false;
   }
 
   $: valid = title.trim().length >= MIN_TITLE_LENGTH;

--- a/ui/src/routes/conversations/new/+page.svelte
+++ b/ui/src/routes/conversations/new/+page.svelte
@@ -24,7 +24,7 @@
     pendingCreate = true;
     try {
       const conversationStore = await relayStore.createConversation(title, imageUrl, privacy);
-      goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}`);
+      await goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}`);
     } catch (e) {
       toast.error(`${$t("common.create_conversation_error")}: ${e.message}`);
     }

--- a/ui/src/routes/create/+page.svelte
+++ b/ui/src/routes/create/+page.svelte
@@ -89,7 +89,7 @@
         Privacy.Private,
         selectedContacts,
       );
-      goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}/details`);
+      await goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}/details`);
     } catch (e) {
       toast.error(`${$t("common.create_conversation_error")}: ${e.message}`);
     }

--- a/ui/src/routes/create/+page.svelte
+++ b/ui/src/routes/create/+page.svelte
@@ -11,6 +11,7 @@
   import { Privacy } from "../../types";
   import type { AgentPubKeyB64 } from "@holochain/client";
   import { xor } from "lodash-es";
+  import toast from "svelte-french-toast";
 
   const relayStoreContext: { getStore: () => RelayStore } = getContext("relayStore");
   let relayStore = relayStoreContext.getStore();
@@ -72,25 +73,25 @@
     }
 
     pendingCreate = true;
-
-    let title = "";
-    if (selectedContactStores.length === 1) {
-      const c = get(selectedContactStores[0]);
-      title = c.fullName;
-    } else if (selectedContacts.length === 2) {
-      title = selectedContactStores.map((c) => get(c).contact.first_name).join(" & ");
-    } else if (selectedContacts.length > 2) {
-      title = selectedContactStores.map((c) => get(c).contact.first_name).join(", ");
-    }
-
-    const conversationStore = await relayStore.createConversation(
-      title,
-      "",
-      Privacy.Private,
-      selectedContacts,
-    );
-    if (conversationStore) {
+    try {
+      let title = "";
+      if (selectedContactStores.length === 1) {
+        const c = get(selectedContactStores[0]);
+        title = c.fullName;
+      } else if (selectedContacts.length === 2) {
+        title = selectedContactStores.map((c) => get(c).contact.first_name).join(" & ");
+      } else if (selectedContacts.length > 2) {
+        title = selectedContactStores.map((c) => get(c).contact.first_name).join(", ");
+      }
+      const conversationStore = await relayStore.createConversation(
+        title,
+        "",
+        Privacy.Private,
+        selectedContacts,
+      );
       goto(`/conversations/${get(conversationStore).conversation.dnaHashB64}/details`);
+    } catch (e) {
+      toast.error(`${$t("common.create_conversation_error")}: ${e.message}`);
     }
     pendingCreate = false;
   }

--- a/ui/src/routes/register/+page.svelte
+++ b/ui/src/routes/register/+page.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import { modeCurrent } from "@skeletonlabs/skeleton";
   import { goto } from "$app/navigation";
   import Button from "$lib/Button.svelte";
   import Header from "$lib/Header.svelte";
-  import SvgIcon from "$lib/SvgIcon.svelte";
   import { t } from "$translations";
   import { ProfileCreateStore } from "$store/ProfileCreateStore";
   import { MIN_FIRST_NAME_LENGTH } from "$config";

--- a/ui/src/routes/scan/+page.svelte
+++ b/ui/src/routes/scan/+page.svelte
@@ -90,7 +90,7 @@
       {#if needsPermission}
         <div class="mt-4">
           <p class="text-error-500 mt-2 text-sm">
-            {$t("common.need_camera_permissions")}
+            {$t("common.need_camera_permission")}
           </p>
         </div>
       {/if}

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -482,6 +482,8 @@ export function createConversationStore(
   }
 
   function addContacts(agentPubKeyB64s: AgentPubKeyB64[]) {
+    if (agentPubKeyB64s.length === 0) return;
+
     localData.update((d) => ({
       ...d,
       invitedContactKeys: [...d.invitedContactKeys, ...agentPubKeyB64s],

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -482,8 +482,6 @@ export function createConversationStore(
   }
 
   function addContacts(agentPubKeyB64s: AgentPubKeyB64[]) {
-    if (agentPubKeyB64s.length === 0) return;
-
     localData.update((d) => ({
       ...d,
       invitedContactKeys: [...d.invitedContactKeys, ...agentPubKeyB64s],

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -121,15 +121,14 @@ export function createConversationStore(
   });
   const lastMessage = writable<Message | null>(null);
   const publicInviteCode = derived(conversation, ($conversation) => {
-    return Base64.fromUint8Array(
-      encode({
-        created: created,
-        networkSeed: $conversation.networkSeed,
-        privacy: $conversation.privacy,
-        progenitor: $conversation.progenitor,
-        title: getTitle(),
-      }),
-    );
+    const invitation: Invitation = {
+      created: created,
+      networkSeed: $conversation.networkSeed,
+      privacy: $conversation.privacy,
+      progenitor: $conversation.progenitor,
+      title: getTitle(),
+    };
+    return Base64.fromUint8Array(encode(invitation));
   });
   const isOpen = derived(
     page,

--- a/ui/src/store/RelayClient.ts
+++ b/ui/src/store/RelayClient.ts
@@ -18,7 +18,6 @@ import type {
   Config,
   Contact,
   ContactRecord,
-  ConversationCellAndConfig,
   ImageStruct,
   Invitation,
   MembraneProofData,

--- a/ui/src/store/RelayClient.ts
+++ b/ui/src/store/RelayClient.ts
@@ -28,7 +28,6 @@ import type {
   Profile,
 } from "../types";
 import { makeFullName } from "$lib/utils";
-import { DEFAULT_CONVERSATION_CONFIG } from "$config";
 
 export class RelayClient {
   constructor(
@@ -193,14 +192,14 @@ export class RelayClient {
     });
   }
 
-  async getConfig(cell_id: CellId): Promise<Config> {
+  async getConfig(cell_id: CellId): Promise<Config | undefined> {
     const config = await this.client.callZome({
       cell_id,
       zome_name: this.zomeName,
       fn_name: "get_config",
       payload: null,
     });
-    return config ? new EntryRecord<Config>(config).entry : DEFAULT_CONVERSATION_CONFIG;
+    return config ? new EntryRecord<Config>(config).entry : undefined;
   }
 
   public async sendMessage(

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -100,7 +100,7 @@ export class RelayStore {
     cellInfo: ClonedCell,
     invitationTitle: string | undefined = undefined,
   ): Promise<ConversationStore> {
-    const properties: DnaProperties = decode(cellInfo.dna_modifiers.properties) as Properties;
+    const properties: DnaProperties = decode(cellInfo.dna_modifiers.properties) as DnaProperties;
     const newConversation = createConversationStore(
       this,
       cellInfo.dna_modifiers.network_seed,

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -17,7 +17,6 @@ import { RelayClient } from "$store/RelayClient";
 import type {
   Contact,
   Image,
-  ConversationCellAndConfig,
   Invitation,
   Message,
   Properties,

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -182,7 +182,6 @@ export class RelayStore {
   }
 
   async updateContact(input: UpdateContactInput) {
-    if (!this.client) return false;
     const contactResult = await this.client.updateContact(input);
     const contactPubKeyB64 = encodeHashToBase64(input.updated_contact.public_key);
 

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -1,6 +1,6 @@
 import { decode } from "@msgpack/msgpack";
 import { camelCase, mapKeys } from "lodash-es";
-import { derived, get, type Readable } from "svelte/store";
+import { derived, get } from "svelte/store";
 import {
   type AgentPubKey,
   type AgentPubKeyB64,

--- a/ui/src/store/RelayStore.ts
+++ b/ui/src/store/RelayStore.ts
@@ -107,7 +107,7 @@ export class RelayStore {
       cellInfo.cell_id,
       properties.created,
       properties.privacy,
-      properties.progenitor,
+      decodeHashFromBase64(properties.progenitor),
       invitationTitle,
     );
     await newConversation.initialize();
@@ -135,6 +135,7 @@ export class RelayStore {
   }
 
   getConversation(dnaHashB64: DnaHashB64): ConversationStore | undefined {
+    console.log("conversations", this.conversations);
     return this.conversations.find((c) => get(c).conversation.dnaHashB64 === dnaHashB64);
   }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -58,7 +58,14 @@ export enum Privacy {
 export interface DnaProperties {
   created: number;
   privacy: Privacy;
-  progenitor: AgentPubKey;
+
+  // This is *NOT* the type specified in the DNA struct Properties (there it is an AgentPubKey)
+  //
+  // But because we have already been cloning cells rom the UI, using an AgentPubKeyB64 as progenitor,
+  // we must keep it consistent to avoid an DNA-integrity breaking change.
+  //
+  // See https://github.com/holochain-apps/volla-messages/issues/392
+  progenitor: AgentPubKeyB64;
 }
 
 export type EntryTypes = { type: "Message" } & MessageInput;
@@ -99,8 +106,8 @@ export interface Invitation {
   networkSeed: string;
   privacy: Privacy;
   progenitor: AgentPubKey;
-  proof?: MembraneProof;
   title: string;
+  proof?: MembraneProof;
 }
 
 // Holochain Type

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -153,11 +153,6 @@ export interface Config {
   image: string;
 }
 
-export interface ConversationCellAndConfig {
-  cell: ClonedCell;
-  config: Config;
-}
-
 /**
  * Contact
  */

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -55,10 +55,10 @@ export enum Privacy {
 }
 
 // DNA modifier properties for a conversation
-export interface Properties {
+export interface DnaProperties {
   created: number;
   privacy: Privacy;
-  progenitor: AgentPubKeyB64;
+  progenitor: AgentPubKey;
 }
 
 export type EntryTypes = { type: "Message" } & MessageInput;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -74,8 +74,7 @@ export interface Conversation {
   networkSeed: string;
   dnaHashB64: DnaHashB64;
   cellId: CellId;
-  config: Config;
-  description?: string;
+  config?: Config;
   privacy: Privacy;
   progenitor: AgentPubKey;
   messages: Messages;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -85,6 +85,7 @@ export interface LocalConversationData {
   archived: boolean;
   invitedContactKeys: string[];
   unread: boolean;
+  invitationTitle?: string;
 }
 
 export interface MembraneProofData {


### PR DESCRIPTION
Extracted from #279 

- Fix follow up on #385, missed a type change
- Split up joinConversation and createConversation client functions for clearer logic
- Avoid passing up conditional responses from client, unless that is what is actually returned from zome call. Instead throw errors.
- Handle errors in components, pass them up otherwise.
- Fix typing of conversation Config, which can be undefined.
- Persist invitation title to local storage for conversation, used for displaying title when conversation Config has not been fetched yet
- increase default zome call timeout to 30s to avoid timing out when cloning cells (it is not configurable per client call, made an issue https://github.com/holochain/holochain-client-js/issues/315)
- Fix typing of DnaProperties and Invitation

**todo**
- [x] Confirm the Invitation structure has *not* changed -- it must be identical to avoid breaking old invitation codes. There may have been mistyping.
- [x] Confirm the dna properties structure has *not* changed -- there may have been mistyping.