### PR TITLE
Fix/invited contact conversationt title

### DIFF
--- a/ui/src/lib/Avatar.svelte
+++ b/ui/src/lib/Avatar.svelte
@@ -4,12 +4,12 @@
   import "@holochain-open-dev/elements/dist/elements/holo-identicon.js";
   import { encodeCellIdToBase64 } from "$lib/utils";
   import {
-    deriveCellMergedProfileContactStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { type CellIdB64 } from "./types";
 
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const provisionedRelayCellId = getContext<{ getCellId: () => CellId }>(
@@ -23,7 +23,7 @@
   export let namePosition = "row";
   export let moreClasses = "";
 
-  $: profiles = deriveCellMergedProfileContactStore(mergedProfileContactStore, cellIdB64);
+  $: profiles = deriveCellMergedProfileContactInviteStore(mergedProfileContactStore, cellIdB64);
   $: profileExtended = $profiles ? $profiles[agentPubKeyB64] : undefined;
   $: title = profileExtended ? profileExtended.profile.nickname : "";
 </script>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -125,7 +125,6 @@ export interface ConversationExtended {
 
   // Locally persisted data
   unread: boolean;
-  invited: AgentPubKeyB64[];
 }
 
 export type BucketInput = {

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -24,11 +24,13 @@
     createConversationTitleStore,
     type ConversationTitleStore,
   } from "$store/ConversationTitleStore";
-  import "../app.postcss";
   import type { CreateProfileInputUI } from "$lib/types";
+  import { createInviteStore, type InviteStore } from "$store/InviteStore";
+  import "../app.postcss";
 
   // Holochain client
   let client: AppClient;
+  let provisionedRelayCellId: CellId;
 
   // Frontend store singletons
   let profileStore: ProfileStore;
@@ -36,7 +38,7 @@
   let mergedProfileContactStore: MergedProfileContactStore;
   let conversationStore: ConversationStore;
   let conversationTitleStore: ConversationTitleStore;
-  let provisionedRelayCellId: CellId;
+  let inviteStore: InviteStore;
 
   // Is the holochain client connected?
   let isClientConnected = false;
@@ -114,6 +116,7 @@
       profileStore = createProfileStore(relayClient);
       mergedProfileContactStore = createMergedProfileContactStore(profileStore, contactStore);
       conversationStore = createConversationStore(relayClient, mergedProfileContactStore);
+      inviteStore = createInviteStore();
       conversationTitleStore = createConversationTitleStore(
         conversationStore,
         mergedProfileContactStore,
@@ -177,6 +180,10 @@
 
   setContext("conversationTitleStore", {
     getStore: () => conversationTitleStore,
+  });
+
+  setContext("inviteStore", {
+    getStore: () => inviteStore,
   });
 </script>
 

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -16,9 +16,9 @@
   import { type ProfileStore, createProfileStore } from "$store/ProfileStore";
   import { encodeCellIdToBase64 } from "$lib/utils";
   import {
-    createMergedProfileContactStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    createMergedProfileContactInviteStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { createConversationStore, type ConversationStore } from "$store/ConversationStore";
   import {
     createConversationTitleStore,
@@ -35,7 +35,7 @@
   // Frontend store singletons
   let profileStore: ProfileStore;
   let contactStore: ContactStore;
-  let mergedProfileContactStore: MergedProfileContactStore;
+  let mergedProfileContactStore: MergedProfileContactInviteStore;
   let conversationStore: ConversationStore;
   let conversationTitleStore: ConversationTitleStore;
   let inviteStore: InviteStore;
@@ -114,9 +114,13 @@
       const relayClient = new RelayClient(client, provisionedRelayCellId);
       contactStore = createContactStore(relayClient);
       profileStore = createProfileStore(relayClient);
-      mergedProfileContactStore = createMergedProfileContactStore(profileStore, contactStore);
-      conversationStore = createConversationStore(relayClient, mergedProfileContactStore);
       inviteStore = createInviteStore();
+      mergedProfileContactStore = createMergedProfileContactInviteStore(
+        profileStore,
+        contactStore,
+        inviteStore,
+      );
+      conversationStore = createConversationStore(relayClient, mergedProfileContactStore);
       conversationTitleStore = createConversationTitleStore(
         conversationStore,
         mergedProfileContactStore,

--- a/ui/src/routes/contacts/new/+page.svelte
+++ b/ui/src/routes/contacts/new/+page.svelte
@@ -12,11 +12,13 @@
   import { decodeHashFromBase64, encodeHashToBase64, type AgentPubKeyB64 } from "@holochain/client";
   import toast from "svelte-french-toast";
   import type { ConversationStore } from "$store/ConversationStore";
+  import type { InviteStore } from "$store/InviteStore";
 
   const contactStore = getContext<{ getStore: () => ContactStore }>("contactStore").getStore();
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
   ).getStore();
+  const inviteStore = getContext<{ getStore: () => InviteStore }>("inviteStore").getStore();
 
   let saving = false;
   let contact: Contact = {
@@ -38,7 +40,7 @@
         privacy: Privacy.Private,
       });
       // Invite agent to conversation
-      await conversationStore.invite(cellIdB64, [encodeHashToBase64(contact.public_key)]);
+      await inviteStore.invite(cellIdB64, [encodeHashToBase64(contact.public_key)]);
 
       // Create contact
       await contactStore.create(contact, cellIdB64);

--- a/ui/src/routes/conversations/ConversationSummary.svelte
+++ b/ui/src/routes/conversations/ConversationSummary.svelte
@@ -10,7 +10,7 @@
   import { goto } from "$app/navigation";
   import { getContext } from "svelte";
   import { type ProfileStore } from "$store/ProfileStore";
-  import { deriveCellMergedProfileContactListStore } from "$store/MergedProfileContactStore";
+  import { deriveCellMergedProfileContactInviteListStore } from "$store/MergedProfileContactInviteStore";
   import MessagePreview from "./MessagePreview.svelte";
   import UnreadIndicator from "./UnreadIndicator.svelte";
   import type { AgentPubKeyB64 } from "@holochain/client";
@@ -38,7 +38,7 @@
   export let cellIdB64: CellIdB64;
 
   let conversation = deriveCellConversationStore(conversationStore, cellIdB64);
-  let mergedProfileContactList = deriveCellMergedProfileContactListStore(
+  let mergedProfileContactList = deriveCellMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     cellIdB64,
     myPubKeyB64,

--- a/ui/src/routes/conversations/ConversationSummary.svelte
+++ b/ui/src/routes/conversations/ConversationSummary.svelte
@@ -19,6 +19,7 @@
     type ConversationTitleStore,
     deriveCellConversationTitleStore,
   } from "$store/ConversationTitleStore";
+  import { deriveCellInviteStore, type InviteStore } from "$store/InviteStore";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
@@ -29,6 +30,7 @@
   const mergedProfileContactStore = getContext<{ getStore: () => ProfileStore }>(
     "mergedProfileContactStore",
   ).getStore();
+  const inviteStore = getContext<{ getStore: () => InviteStore }>("inviteStore").getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
     "myPubKey",
   ).getMyPubKeyB64();
@@ -42,6 +44,7 @@
     myPubKeyB64,
   );
   let conversationTitle = deriveCellConversationTitleStore(conversationTitleStore, cellIdB64);
+  let invite = deriveCellInviteStore(inviteStore, cellIdB64);
 
   let isHovering = false;
   let menuOpen = 0;
@@ -198,7 +201,7 @@
             <UnreadIndicator />
           {/if}
 
-          {#if $conversation.conversation.dnaProperties.privacy === Privacy.Private && $mergedProfileContactList.length === 1 && $conversation.conversation.invited.length > 0}
+          {#if $conversation.conversation.dnaProperties.privacy === Privacy.Private && $mergedProfileContactList.length === 1 && $invite.length > 0}
             <span class="text-secondary-400">{$t("common.unconfirmed")}</span>
           {:else if $conversation.latestMessage}
             <MessagePreview {cellIdB64} messageExtended={$conversation.latestMessage} />

--- a/ui/src/routes/conversations/MessagePreview.svelte
+++ b/ui/src/routes/conversations/MessagePreview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { CellIdB64, MessageExtended } from "$lib/types";
-  import { deriveCellMergedProfileContactStore } from "$store/MergedProfileContactStore";
+  import { deriveCellMergedProfileContactInviteStore } from "$store/MergedProfileContactInviteStore";
   import type { ProfileStore } from "$store/ProfileStore";
   import { t } from "$translations";
   import DOMPurify from "dompurify";
@@ -11,7 +11,7 @@
   export let messageExtended: MessageExtended;
   export let cellIdB64: CellIdB64;
 
-  let profile = deriveCellMergedProfileContactStore(profileStore, cellIdB64);
+  let profile = deriveCellMergedProfileContactInviteStore(profileStore, cellIdB64);
 </script>
 
 <div class="flex items-center justify-start space-x-1">

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -20,9 +20,9 @@
   import { deriveCellProfileStore, type ProfileStore } from "$store/ProfileStore";
   import { toast } from "svelte-french-toast";
   import {
-    deriveCellMergedProfileContactListStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteListStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import {
     type ConversationTitleStore,
     deriveCellConversationTitleStore,
@@ -32,7 +32,7 @@
     "conversationStore",
   ).getStore();
   const profileStore = getContext<{ getStore: () => ProfileStore }>("profileStore").getStore();
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
@@ -45,7 +45,7 @@
   let conversation = deriveCellConversationStore(conversationStore, $page.params.id);
   let messagesList = deriveCellConversationMessagesListStore(conversation);
   let profiles = deriveCellProfileStore(profileStore, $page.params.id);
-  let mergedProfileContactList = deriveCellMergedProfileContactListStore(
+  let mergedProfileContactList = deriveCellMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     $page.params.id,
     myPubKeyB64,
@@ -193,7 +193,7 @@
 </script>
 
 <Header backUrl="/conversations">
-  <h1 slot="center" class="overflow-hidden text-ellipsis whitespace-nowrap text-center p-4">
+  <h1 slot="center" class="overflow-hidden text-ellipsis whitespace-nowrap p-4 text-center">
     {$conversationTitle}
   </h1>
 

--- a/ui/src/routes/conversations/[id]/ConversationEmpty.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationEmpty.svelte
@@ -8,9 +8,9 @@
   import { type ProfileStore, deriveCellProfileStore } from "$store/ProfileStore";
   import type { AgentPubKeyB64 } from "@holochain/client";
   import {
-    deriveCellMergedProfileContactListStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteListStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { page } from "$app/stores";
   import {
     deriveCellConversationTitleStore,
@@ -21,7 +21,7 @@
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
   ).getStore();
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const profileStore = getContext<{ getStore: () => ProfileStore }>("profileStore").getStore();
@@ -31,7 +31,7 @@
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
     "myPubKey",
   ).getMyPubKeyB64();
-  let mergedProfileContactList = deriveCellMergedProfileContactListStore(
+  let mergedProfileContactList = deriveCellMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     $page.params.id,
     myPubKeyB64,

--- a/ui/src/routes/conversations/[id]/ConversationEmpty.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationEmpty.svelte
@@ -16,6 +16,7 @@
     deriveCellConversationTitleStore,
     type ConversationTitleStore,
   } from "$store/ConversationTitleStore";
+  import { deriveCellInviteStore, type InviteStore } from "$store/InviteStore";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
@@ -38,12 +39,14 @@
   const conversationTitleStore = getContext<{ getStore: () => ConversationTitleStore }>(
     "conversationTitleStore",
   ).getStore();
+  const inviteStore = getContext<{ getStore: () => InviteStore }>("inviteStore").getStore();
 
   export let cellIdB64: CellIdB64;
 
   let conversation = deriveCellConversationStore(conversationStore, cellIdB64);
   let profiles = deriveCellProfileStore(profileStore, provisionedRelayCellIdB64);
   let conversationTitle = deriveCellConversationTitleStore(conversationTitleStore, cellIdB64);
+  let invite = deriveCellInviteStore(inviteStore, cellIdB64);
 
   $: invitationTitle =
     $mergedProfileContactList.length === 1
@@ -70,7 +73,7 @@
         })}
       </p>
 
-      {#await conversation.makePrivateInviteCode($conversation.conversation.invited[0], invitationTitle) then text}
+      {#await conversation.makePrivateInviteCode($invite[0], invitationTitle) then text}
         <div class="flex justify-center">
           <ButtonsCopyShare
             moreClasses="bg-tertiary-600 dark:bg-secondary-700"

--- a/ui/src/routes/conversations/[id]/ConversationMessages.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationMessages.svelte
@@ -5,18 +5,18 @@
   import BaseMessage from "./Message.svelte";
   import { getContext } from "svelte";
   import {
-    deriveCellMergedProfileContactStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
 
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
 
   export let messages: [ActionHashB64, MessageExtended][];
   export let cellIdB64: CellIdB64;
 
-  let mergedProfileContact = deriveCellMergedProfileContactStore(
+  let mergedProfileContact = deriveCellMergedProfileContactInviteStore(
     mergedProfileContactStore,
     cellIdB64,
   );

--- a/ui/src/routes/conversations/[id]/Message.svelte
+++ b/ui/src/routes/conversations/[id]/Message.svelte
@@ -11,15 +11,15 @@
   import MessageFilePreview from "./MessageFilePreview.svelte";
   import type { AgentPubKeyB64 } from "@holochain/client";
   import {
-    deriveCellMergedProfileContactStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { decodeCellIdFromBase64 } from "$lib/utils";
 
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
     "myPubKey",
   ).getMyPubKeyB64();
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
 
@@ -29,7 +29,7 @@
   export let showAuthor: boolean = false;
   export let showDate: boolean = false;
 
-  let mergedProfileContact = deriveCellMergedProfileContactStore(
+  let mergedProfileContact = deriveCellMergedProfileContactInviteStore(
     mergedProfileContactStore,
     cellIdB64,
   );

--- a/ui/src/routes/conversations/[id]/PrivateConversationImage.svelte
+++ b/ui/src/routes/conversations/[id]/PrivateConversationImage.svelte
@@ -3,13 +3,13 @@
   import type { CellIdB64 } from "$lib/types";
   ("$store/ConversationStore");
   import {
-    deriveCellMergedProfileContactListStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteListStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { getContext } from "svelte";
   import type { AgentPubKeyB64 } from "@holochain/client";
 
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
@@ -18,7 +18,7 @@
 
   export let cellIdB64: CellIdB64;
 
-  let mergedProfileContactList = deriveCellMergedProfileContactListStore(
+  let mergedProfileContactList = deriveCellMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     cellIdB64,
     myPubKeyB64,

--- a/ui/src/routes/conversations/[id]/PrivateConversationImageThumbnail.svelte
+++ b/ui/src/routes/conversations/[id]/PrivateConversationImageThumbnail.svelte
@@ -3,14 +3,14 @@
   import type { CellIdB64 } from "$lib/types";
   ("$store/ConversationStore");
   import {
-    deriveCellMergedProfileContactListStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteListStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { getContext } from "svelte";
   import type { AgentPubKeyB64 } from "@holochain/client";
   import SvgIcon from "$lib/SvgIcon.svelte";
 
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
@@ -19,7 +19,7 @@
 
   export let cellIdB64: CellIdB64;
 
-  let mergedProfileContactList = deriveCellMergedProfileContactListStore(
+  let mergedProfileContactList = deriveCellMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     cellIdB64,
     myPubKeyB64,

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -24,6 +24,7 @@
     type ConversationTitleStore,
     deriveCellConversationTitleStore,
   } from "$store/ConversationTitleStore";
+  import { deriveCellInviteStore, type InviteStore } from "$store/InviteStore";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
@@ -41,6 +42,7 @@
   const conversationTitleStore = getContext<{ getStore: () => ConversationTitleStore }>(
     "conversationTitleStore",
   ).getStore();
+  const inviteStore = getContext<{ getStore: () => InviteStore }>("inviteStore").getStore();
 
   let conversation = deriveCellConversationStore(conversationStore, $page.params.id);
   let conversationTitle = deriveCellConversationTitleStore(conversationTitleStore, $page.params.id);
@@ -54,6 +56,7 @@
     myPubKeyB64,
   );
   let profiles = deriveCellProfileStore(profileStore, provisionedRelayCellIdB64);
+  let invite = deriveCellInviteStore(inviteStore, $page.params.id);
 
   $: myProfile = $profiles[myPubKeyB64];
   $: invitationTitle =
@@ -67,9 +70,7 @@
   let editingTitle = false;
 
   $: iAmProgenitor = myPubKeyB64 === $conversation.conversation.dnaProperties.progenitor;
-  $: invitedUnjoinedAgentPubKeyB64s = $conversation.conversation.invited.filter(
-    (a) => !(a in $mergedProfileContact),
-  );
+  $: invitedUnjoinedAgentPubKeyB64s = $invite.filter((a) => !(a in $mergedProfileContact));
 
   const saveTitle = async (newTitle: string) => {
     conversation.updateConfig({ title: newTitle.trim(), image });
@@ -87,7 +88,7 @@
 </script>
 
 <Header backUrl={`/conversations/${$page.params.id}`}>
-  <h1 slot="center" class="overflow-hidden text-ellipsis whitespace-nowrap text-center p-4">
+  <h1 slot="center" class="overflow-hidden text-ellipsis whitespace-nowrap p-4 text-center">
     {$conversationTitle}
   </h1>
 

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -13,10 +13,10 @@
   import InputImageAvatar from "$lib/InputImageAvatar.svelte";
   import { deriveCellConversationStore, type ConversationStore } from "$store/ConversationStore";
   import {
-    deriveCellMergedProfileContactListStore,
-    deriveCellMergedProfileContactStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteListStore,
+    deriveCellMergedProfileContactInviteStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import MemberListItem from "./MemberListItem.svelte";
   import PrivateConversationImage from "../PrivateConversationImage.svelte";
   import { type ProfileStore, deriveCellProfileStore } from "$store/ProfileStore";
@@ -29,7 +29,7 @@
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
   ).getStore();
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
@@ -46,11 +46,11 @@
 
   let conversation = deriveCellConversationStore(conversationStore, $page.params.id);
   let conversationTitle = deriveCellConversationTitleStore(conversationTitleStore, $page.params.id);
-  let mergedProfileContact = deriveCellMergedProfileContactStore(
+  let mergedProfileContact = deriveCellMergedProfileContactInviteStore(
     mergedProfileContactStore,
     $page.params.id,
   );
-  let mergedProfileContactList = deriveCellMergedProfileContactListStore(
+  let mergedProfileContactList = deriveCellMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     $page.params.id,
     myPubKeyB64,

--- a/ui/src/routes/conversations/[id]/details/MemberListItem.svelte
+++ b/ui/src/routes/conversations/[id]/details/MemberListItem.svelte
@@ -4,9 +4,9 @@
   import type { ContactStore } from "$store/ContactStore";
   import { type ConversationStore, deriveCellConversationStore } from "$store/ConversationStore";
   import {
-    type MergedProfileContactStore,
-    deriveCellMergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    type MergedProfileContactInviteStore,
+    deriveCellMergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { t } from "$translations";
   import type { AgentPubKeyB64 } from "@holochain/client";
   import { getContext } from "svelte";
@@ -14,7 +14,7 @@
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
   ).getStore();
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const contactStore = getContext<{ getStore: () => ContactStore }>("contactStore").getStore();
@@ -26,7 +26,7 @@
   export let agentPubKeyB64: AgentPubKeyB64;
 
   let conversation = deriveCellConversationStore(conversationStore, cellIdB64);
-  let mergedProfileContact = deriveCellMergedProfileContactStore(
+  let mergedProfileContact = deriveCellMergedProfileContactInviteStore(
     mergedProfileContactStore,
     cellIdB64,
   );

--- a/ui/src/routes/conversations/[id]/invite/+page.svelte
+++ b/ui/src/routes/conversations/[id]/invite/+page.svelte
@@ -11,16 +11,16 @@
   import InputContactsSelect from "$lib/InputContactsSelect.svelte";
   import { deriveCellConversationStore, type ConversationStore } from "$store/ConversationStore";
   import {
-    deriveCellMergedProfileContactListStore,
-    type MergedProfileContactStore,
-  } from "$store/MergedProfileContactStore";
+    deriveCellMergedProfileContactInviteListStore,
+    type MergedProfileContactInviteStore,
+  } from "$store/MergedProfileContactInviteStore";
   import { uniq } from "lodash-es";
   import { deriveCellInviteStore, type InviteStore } from "$store/InviteStore";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
   ).getStore();
-  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactStore }>(
+  const mergedProfileContactStore = getContext<{ getStore: () => MergedProfileContactInviteStore }>(
     "mergedProfileContactStore",
   ).getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
@@ -29,7 +29,7 @@
   const inviteStore = getContext<{ getStore: () => InviteStore }>("inviteStore").getStore();
 
   let conversation = deriveCellConversationStore(conversationStore, $page.params.id);
-  let profiles = deriveCellMergedProfileContactListStore(
+  let profiles = deriveCellMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     $page.params.id,
     myPubKeyB64,

--- a/ui/src/routes/create/+page.svelte
+++ b/ui/src/routes/create/+page.svelte
@@ -17,6 +17,7 @@
     "conversationStore",
   ).getStore();
   const profileStore = getContext<{ getStore: () => ProfileStore }>("profileStore").getStore();
+  const inviteStore = getContext<{ getStore: () => InviteStore }>("inviteStore").getStore();
 
   let searchQuery = "";
   let creating = false;
@@ -45,7 +46,7 @@
         },
         privacy: Privacy.Private,
       });
-      await conversationStore.invite(cellIdB64, selectedAgentPubKeyB64s);
+      await inviteStore.invite(cellIdB64, selectedAgentPubKeyB64s);
       await goto(`/conversations/${cellIdB64}/details`);
     } catch (e) {
       toast.error(`${$t("common.create_conversation_error")}: ${e}`);

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -46,9 +46,9 @@ import pRetry from "p-retry";
 import { BUCKET_RANGE_MS } from "$config";
 import { difference, sortBy } from "lodash-es";
 import {
-  deriveCellMergedProfileContactStore,
-  type MergedProfileContactStore,
-} from "./MergedProfileContactStore";
+  deriveCellMergedProfileContactInviteStore,
+  type MergedProfileContactInviteStore,
+} from "./MergedProfileContactInviteStore";
 
 export interface ConversationStore {
   initialize: () => Promise<void>;
@@ -87,7 +87,7 @@ export interface ConversationStore {
 
 export function createConversationStore(
   client: RelayClient,
-  mergedProfileContactStore: MergedProfileContactStore,
+  mergedProfileContactStore: MergedProfileContactInviteStore,
 ): ConversationStore {
   const conversations = createGenericKeyValueStore<ConversationExtended>();
   const messages = createGenericKeyKeyValueStore<MessageExtended>();
@@ -306,7 +306,7 @@ export function createConversationStore(
 
     // Get all AgentPubKeys in the conversation.
     // We know about them only because they have published a Profile.
-    const mergedProfileContact = deriveCellMergedProfileContactStore(
+    const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
       mergedProfileContactStore,
       key1,
     );
@@ -413,7 +413,7 @@ export function createConversationStore(
     }));
 
     // Get Profile of Message author
-    const mergedProfileContact = deriveCellMergedProfileContactStore(
+    const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
       mergedProfileContactStore,
       key1,
     );

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -59,7 +59,6 @@ export interface ConversationStore {
   enable: (key: CellIdB64) => Promise<void>;
   disable: (key: CellIdB64) => Promise<void>;
   updateUnread: (key: CellIdB64, val: boolean) => Promise<void>;
-  invite: (key: CellIdB64, agents: AgentPubKeyB64[]) => Promise<void>;
   makePrivateInviteCode: (
     key: CellIdB64,
     agentPubKeyB64: AgentPubKeyB64,
@@ -95,12 +94,6 @@ export function createConversationStore(
 
   // Unread is persisted to localstorage as it is never stored via holochain
   const unread = persisted<{ [cellIdB64: CellIdB64]: boolean }>("CONVERSATION.UNREAD", {});
-
-  // List of invited agents is persisted to localstorage as it is not stored via holochain
-  const invited = persisted<{ [cellIdB64: CellIdB64]: AgentPubKeyB64[] }>(
-    "CONVERSATION.INVITED",
-    {},
-  );
 
   // Invitation I used to join conversation is persisted to localstorage to ensure it remains available when the cell is disabled.
   const invitation = persisted<{ [cellIdB64: CellIdB64]: Invitation | undefined }>(
@@ -263,20 +256,6 @@ export function createConversationStore(
     }));
   }
 
-  async function invite(key: CellIdB64, agentPubKeyB64s: AgentPubKeyB64[]): Promise<void> {
-    invited.update((c) => ({
-      ...c,
-      [key]: [...(c[key] || []), ...agentPubKeyB64s],
-    }));
-    conversations.update((c) => ({
-      ...c,
-      [key]: {
-        ...c[key],
-        invited: get(invited)[key],
-      },
-    }));
-  }
-
   async function makePrivateInviteCode(
     key: CellIdB64,
     agentPubKeyB64: AgentPubKeyB64,
@@ -291,7 +270,6 @@ export function createConversationStore(
       decodeHashFromBase64(agentPubKeyB64),
     );
 
-    // TODO The name of the conversation we are inviting to should be our name + # of other people invited
     const invitation: Invitation = {
       created: c.dnaProperties.created,
       progenitor: decodeHashFromBase64(c.dnaProperties.progenitor),
@@ -488,7 +466,6 @@ export function createConversationStore(
 
       // persisted fields
       unread: get(unread)[key] || false,
-      invited: get(invited)[key] || [],
     };
   }
 
@@ -565,7 +542,6 @@ export function createConversationStore(
     enable,
     disable,
     updateUnread,
-    invite,
     makePrivateInviteCode,
 
     sendMessage,
@@ -583,7 +559,6 @@ export interface CellConversationStore {
   enable: () => Promise<void>;
   disable: () => Promise<void>;
   updateUnread: (val: boolean) => Promise<void>;
-  invite: (a: AgentPubKeyB64[]) => Promise<void>;
   makePrivateInviteCode: (a: AgentPubKeyB64, title: string) => Promise<string>;
   sendMessage: (content: string, files: LocalFile[]) => Promise<void>;
   loadMessagesInBucket: (bucket: number) => Promise<void>;
@@ -622,7 +597,6 @@ export function deriveCellConversationStore(
     enable: () => conversationStore.enable(key),
     disable: () => conversationStore.disable(key),
     updateUnread: (val: boolean) => conversationStore.updateUnread(key, val),
-    invite: (a: AgentPubKeyB64[]) => conversationStore.invite(key, a),
     makePrivateInviteCode: (a: AgentPubKeyB64, title: string) =>
       conversationStore.makePrivateInviteCode(key, a, title),
     sendMessage: (content: string, files: LocalFile[]) =>

--- a/ui/src/store/ConversationTitleStore.ts
+++ b/ui/src/store/ConversationTitleStore.ts
@@ -1,10 +1,9 @@
 import { derived, get, type Invalidator, type Subscriber, type Unsubscriber } from "svelte/store";
 import type { ConversationStore } from "./ConversationStore";
 import {
-  deriveCellMergedProfileContactListStore,
-  deriveMergedProfileContactListStore,
-  type MergedProfileContactStore,
-} from "./MergedProfileContactStore";
+  deriveMergedProfileContactInviteListStore,
+  type MergedProfileContactInviteStore,
+} from "./MergedProfileContactInviteStore";
 import { Privacy, type CellIdB64, type ProfileExtended } from "$lib/types";
 import type { AgentPubKeyB64 } from "@holochain/client";
 import { persisted } from "./GenericPersistedStore";
@@ -20,12 +19,12 @@ export interface ConversationTitleStore {
 
 export function createConversationTitleStore(
   conversationStore: ConversationStore,
-  mergedProfileContactStore: MergedProfileContactStore,
+  mergedProfileContactStore: MergedProfileContactInviteStore,
   myPubKeyB64: AgentPubKeyB64,
 ): ConversationTitleStore {
   const persistedData = persisted<{ [cellIdB64: CellIdB64]: string }>("CONVERSATION.TITLE", {});
 
-  const mergedProfileContactList = deriveMergedProfileContactListStore(
+  const mergedProfileContactList = deriveMergedProfileContactInviteListStore(
     mergedProfileContactStore,
     myPubKeyB64,
   );
@@ -37,7 +36,6 @@ export function createConversationTitleStore(
           const previousTitle = get(persistedData)[cellIdB64];
 
           let title;
-
           if (
             previousTitle !== undefined &&
             (!conversation.cellInfo.enabled ||
@@ -87,6 +85,7 @@ export function deriveCellConversationTitleStore(
 }
 
 function makePrivateConversationTitle(profiles: ProfileExtended[]) {
+  console.log('makePrivateConversationTitle', profiles);
   let title;
   if (profiles.length === 2) {
     // Full name of the one other person in the chat

--- a/ui/src/store/InviteStore.ts
+++ b/ui/src/store/InviteStore.ts
@@ -1,0 +1,41 @@
+import type { CellIdB64 } from "$lib/types";
+import type { AgentPubKeyB64 } from "@holochain/client";
+import { persisted } from "./GenericPersistedStore";
+import  { type Subscriber, type Invalidator, type Unsubscriber, derived } from "svelte/store";
+
+export interface InviteStore {
+    invite: (key: CellIdB64, agentPubKeyB64s: AgentPubKeyB64[]) => Promise<void>;
+    subscribe: (this: void, run: Subscriber<{
+        [cellIdB64: string]: string[];
+    }>, invalidate?: Invalidator<{
+        [cellIdB64: string]: string[];
+    }> | undefined) => Unsubscriber;
+}
+
+export function createInviteStore(): InviteStore {
+    // List of invited agents is persisted to localstorage as it is not stored via holochain
+    const invited = persisted<{ [cellIdB64: CellIdB64]: AgentPubKeyB64[] }>(
+        "CONVERSATION.INVITED",
+        {},
+    );
+
+    async function invite(key: CellIdB64, agentPubKeyB64s: AgentPubKeyB64[]): Promise<void> {
+      invited.update((c) => ({
+        ...c,
+        [key]: [...(c[key] || []), ...agentPubKeyB64s],
+      }));
+    }
+
+    return {
+      invite,
+      subscribe: invited.subscribe
+    };
+}
+
+export function deriveCellInviteStore(inviteStore: InviteStore, cellIdB64: CellIdB64) {
+    const { subscribe } =  derived(inviteStore, ($inviteStore) => $inviteStore[cellIdB64]);
+    return {
+      invite: (agentPubKeyB64s: AgentPubKeyB64[]) => inviteStore.invite(cellIdB64, agentPubKeyB64s),
+      subscribe
+    }
+}

--- a/ui/src/store/InviteStore.ts
+++ b/ui/src/store/InviteStore.ts
@@ -1,41 +1,47 @@
 import type { CellIdB64 } from "$lib/types";
 import type { AgentPubKeyB64 } from "@holochain/client";
 import { persisted } from "./GenericPersistedStore";
-import  { type Subscriber, type Invalidator, type Unsubscriber, derived } from "svelte/store";
+import { type Subscriber, type Invalidator, type Unsubscriber, derived } from "svelte/store";
 
 export interface InviteStore {
-    invite: (key: CellIdB64, agentPubKeyB64s: AgentPubKeyB64[]) => Promise<void>;
-    subscribe: (this: void, run: Subscriber<{
-        [cellIdB64: string]: string[];
-    }>, invalidate?: Invalidator<{
-        [cellIdB64: string]: string[];
-    }> | undefined) => Unsubscriber;
+  invite: (key: CellIdB64, agentPubKeyB64s: AgentPubKeyB64[]) => Promise<void>;
+  subscribe: (
+    this: void,
+    run: Subscriber<{
+      [cellIdB64: string]: string[];
+    }>,
+    invalidate?:
+      | Invalidator<{
+          [cellIdB64: string]: string[];
+        }>
+      | undefined,
+  ) => Unsubscriber;
 }
 
 export function createInviteStore(): InviteStore {
-    // List of invited agents is persisted to localstorage as it is not stored via holochain
-    const invited = persisted<{ [cellIdB64: CellIdB64]: AgentPubKeyB64[] }>(
-        "CONVERSATION.INVITED",
-        {},
-    );
+  // List of invited agents is persisted to localstorage as it is not stored via holochain
+  const invited = persisted<{ [cellIdB64: CellIdB64]: AgentPubKeyB64[] }>(
+    "CONVERSATION.INVITED",
+    {},
+  );
 
-    async function invite(key: CellIdB64, agentPubKeyB64s: AgentPubKeyB64[]): Promise<void> {
-      invited.update((c) => ({
-        ...c,
-        [key]: [...(c[key] || []), ...agentPubKeyB64s],
-      }));
-    }
+  async function invite(key: CellIdB64, agentPubKeyB64s: AgentPubKeyB64[]): Promise<void> {
+    invited.update((c) => ({
+      ...c,
+      [key]: [...(c[key] || []), ...agentPubKeyB64s],
+    }));
+  }
 
-    return {
-      invite,
-      subscribe: invited.subscribe
-    };
+  return {
+    invite,
+    subscribe: invited.subscribe,
+  };
 }
 
 export function deriveCellInviteStore(inviteStore: InviteStore, cellIdB64: CellIdB64) {
-    const { subscribe } =  derived(inviteStore, ($inviteStore) => $inviteStore[cellIdB64]);
-    return {
-      invite: (agentPubKeyB64s: AgentPubKeyB64[]) => inviteStore.invite(cellIdB64, agentPubKeyB64s),
-      subscribe
-    }
+  const { subscribe } = derived(inviteStore, ($inviteStore) => $inviteStore[cellIdB64]);
+  return {
+    invite: (agentPubKeyB64s: AgentPubKeyB64[]) => inviteStore.invite(cellIdB64, agentPubKeyB64s),
+    subscribe,
+  };
 }


### PR DESCRIPTION
Follow up on #409 

- Add InviteStore to hold invites list for each conversation
- Modify MergedProfileContactInviteStore to also derive from InviteStore, include invited agents in list
- Modify conversation/[id]/details page to list joined and invited agents separately, using new stores.