### PR TITLE
feat(ui): always poll for config, profiles and messages on Conversation Page

### DIFF
--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -23,3 +23,7 @@ export const INPUT_MAX_FILENAME_LENGTH = 10;
 
 export const ROLE_NAME = "relay";
 export const ZOME_NAME = "relay";
+
+// Polling intervals, used on conversations page
+export const POLLING_INTERVAL_SLOW = 30 * 1000;
+export const POLLING_INTERVAL_FAST = 2 * 1000;

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -27,6 +27,7 @@
     deriveCellMergedProfileContactInviteJoinedStore,
     type MergedProfileContactInviteJoinedStore,
   } from "$store/MergedProfileContactInviteJoinedStore";
+  import { POLLING_INTERVAL_FAST, POLLING_INTERVAL_SLOW } from "$config";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
@@ -86,11 +87,11 @@
     if ($joined.count < 2) {
       agentTimeout = setTimeout(() => {
         loadProfiles();
-      }, 2000);
+      }, POLLING_INTERVAL_FAST);
     } else {
       agentTimeout = setTimeout(() => {
         loadProfiles();
-      }, 15000);
+      }, POLLING_INTERVAL_SLOW);
     }
   }
 
@@ -106,7 +107,11 @@
     if ($conversation.config === undefined) {
       configTimeout = setTimeout(() => {
         loadConfig();
-      }, 2000);
+      }, POLLING_INTERVAL_FAST);
+    } else {
+      configTimeout = setTimeout(() => {
+        loadConfig();
+      }, POLLING_INTERVAL_SLOW);
     }
   }
 
@@ -119,7 +124,11 @@
     if ($messages.count === 0) {
       messageTimeout = setTimeout(() => {
         loadMessages();
-      }, 2000);
+      }, POLLING_INTERVAL_FAST);
+    } else {
+      messageTimeout = setTimeout(() => {
+        loadMessages();
+      }, POLLING_INTERVAL_SLOW);
     }
   }
 


### PR DESCRIPTION
Improves #423 

- Always poll for conversations, messages and config on Conversation page.
- Every 2s until we have some data
- Then every 30s 