### PR TITLE
feat(ui): display messages from agents even when we do not have their profile

### DIFF
--- a/ui/src/lib/AgentNickname.svelte
+++ b/ui/src/lib/AgentNickname.svelte
@@ -8,17 +8,17 @@
   import type { AgentPubKeyB64 } from "@holochain/client";
   import { getContext } from "svelte";
 
-      const mergedProfileContactInviteStore = getContext<{
+  const mergedProfileContactInviteStore = getContext<{
     getStore: () => MergedProfileContactInviteStore;
   }>("mergedProfileContactInviteStore").getStore();
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
     "myPubKey",
   ).getMyPubKeyB64();
 
-    export let agentPubKeyB64: AgentPubKeyB64;
-    export let cellIdB64: CellIdB64;
+  export let agentPubKeyB64: AgentPubKeyB64;
+  export let cellIdB64: CellIdB64;
 
-    let profile = deriveCellMergedProfileContactInviteStore(
+  let profile = deriveCellMergedProfileContactInviteStore(
     mergedProfileContactInviteStore,
     cellIdB64,
     myPubKeyB64,
@@ -29,13 +29,15 @@
     $profile.data[agentPubKeyB64] !== undefined
       ? $profile.data[agentPubKeyB64].profile.nickname
       : undefined;
-    $: agentPubKeyB64Sliced = agentPubKeyB64.slice(4, 14);
+  $: agentPubKeyB64Sliced = agentPubKeyB64.slice(4, 14);
 </script>
 
 <div>
-{#if isMe}
+  {#if isMe}
     <span class="font-bold">{$t("common.you")}</span>
-{:else if nickname !== undefined}
-  <span class="font-bold">{nickname}</span>
-{/if}
+  {:else if nickname !== undefined}
+    <span class="font-bold">{nickname}</span>
+  {:else}
+    <span><code>{agentPubKeyB64Sliced}</code>...</span>
+  {/if}
 </div>

--- a/ui/src/lib/Avatar.svelte
+++ b/ui/src/lib/Avatar.svelte
@@ -32,11 +32,10 @@
   );
 
   $: profile = $profiles.data[agentPubKeyB64];
-  $: title = profile ? profile.profile.nickname : "";
 </script>
 
-<div class="avatar-{namePosition} {moreClasses}" {title}>
-  {#if profile && profile.profile.fields.avatar}
+<div class="avatar-{namePosition} {moreClasses}">
+  {#if profile?.profile.fields.avatar}
     <div
       class="flex h-[150px] w-[150px] items-center justify-center overflow-hidden rounded-full"
       style="width: {size}px; height: {size}px"

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -61,33 +61,6 @@ export function createConversationMessageStore(
 ): ConversationMessageStore {
   const messages = createGenericKeyKeyValueStore<MessageExtended>();
 
-  // Filter out messages by agents who do not have a Contact nor Profile
-  const { subscribe } = derived(
-    [messages, mergedProfileContactInviteStore],
-    ([$messages, $mergedProfileContactInviteStore]) => {
-      const filteredMessages = Object.fromEntries(
-        $messages.list.map(([cellIdB64, messagesData]) => [
-          cellIdB64,
-          Object.fromEntries(
-            Object.entries(messagesData).filter(
-              ([, messageExtended]) =>
-                $mergedProfileContactInviteStore.data[cellIdB64] !== undefined &&
-                $mergedProfileContactInviteStore.data[cellIdB64][
-                  messageExtended.authorAgentPubKeyB64
-                ] !== undefined,
-            ),
-          ),
-        ]),
-      );
-
-      return {
-        data: filteredMessages,
-        list: Object.entries(filteredMessages),
-        count: Object.keys(filteredMessages).length,
-      };
-    },
-  );
-
   async function initialize() {
     const cellInfos = await client.getRelayClonedCellInfos();
 
@@ -450,7 +423,6 @@ export function createConversationMessageStore(
     loadMessagesInPreviousBucketTargetCount,
     sendMessage,
     handleMessageSignalReceived,
-    subscribe,
   };
 }
 

--- a/ui/src/store/MergedProfileContactInviteStore.ts
+++ b/ui/src/store/MergedProfileContactInviteStore.ts
@@ -114,6 +114,10 @@ export function deriveCellMergedProfileContactInviteStore(
     ([agentPubKeyB64]) => agentPubKeyB64 !== myAgentPubKeyB64,
 
     // Then by nickname alphabetically
-    ([, profileExtended]) => profileExtended.profile.nickname,
+    ([, profileExtended]) =>
+      profileExtended ? profileExtended.profile.nickname : Number.MAX_SAFE_INTEGER,
+
+    // Then by AgentPubKeyB64 alphabetically
+    ([, profileExtended]) => profileExtended.publicKeyB64,
   ]);
 }


### PR DESCRIPTION
### Summary
I wanted to put up this draft PR for consideration. By hiding messages from members who do not have profiles we're choosing not to display some data to the user, just because it is incomplete.

Since we know holochain gossip is currently slower and buggier than it should be, choosing not to display some data provides a worse user experience than necessary of "slow syncronization".

I would recommend we take this on.

### TODO:
- [ ] Hovering / tapping AgentNickname displays the full agentpubkey
- [ ] Ensure agents without profiles still appear in the members list of the /conversation/[id]/details page
- [ ] CHANGELOG updated