### PR TITLE
fix(ui): display 'unconfirmed' when agent has *not* joined dht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix: Display "unconfirmed" label for contacts that have not yet joined their private conversation.
+
 ## [0.7.5] - 2025-01-10
 
 - Fix: Major refactoring of the frontend data stores for clarity, readability, maintainability, reducing bugs related to frontend state, following svelte conventions.

--- a/ui/src/lib/ContactListItem.svelte
+++ b/ui/src/lib/ContactListItem.svelte
@@ -61,7 +61,7 @@
       : ''}"
   >
     {$contact.fullName}
-    {#if hasAgentJoinedDht}
+    {#if !hasAgentJoinedDht}
       <span class="text-secondary-400 ml-1 text-xs">{$t("common.unconfirmed")}</span>
     {/if}
   </p>


### PR DESCRIPTION
### Summary
follow up to #409 

### TODO:
- [x] CHANGELOG updated