### PR TITLE
Fix/public invite code title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Fix: Display "unconfirmed" label for contacts that have not yet joined their private conversation.
+- Fix: In public converastion invitations, use the cell name as the conversation title when convesation config is not available.
 
 ## [0.7.5] - 2025-01-10
 

--- a/ui/src/store/ConversationStore.ts
+++ b/ui/src/store/ConversationStore.ts
@@ -199,7 +199,7 @@ export function createConversationStore(client: RelayClient): ConversationStore 
         networkSeed: cellInfo.dna_modifiers.network_seed,
         privacy: dnaProperties.privacy,
         progenitor: decodeHashFromBase64(dnaProperties.progenitor),
-        title: config ? config.title : "...",
+        title: config ? config.title : cellInfo.name,
       };
       publicInviteCode = Base64.fromUint8Array(encode(invitation));
     }


### PR DESCRIPTION
### Summary
Follow up on #409 

In public converastion invitations, use the cell name as the conversation title when conversation config is not available

### TODO:
- [x] CHANGELOG updated