### PR TITLE
refactor: use uuid to generate random network seed, not system timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feat: Delete a contact by clicking the "Delete Contact" button on their page.
 - Feat: Added 2 features: Feature `holochain_bundled` bundles a holochain conductor with the app (the previous behavior). Feature `holochain_service` relies on a holochain conductor provided by the Android Service Runtime app.
 - Feat: CI builds a "rich" and "lite" version of the android app, where the "rich" version uses feature `holochain_bundled`, and the "lite" version uses feature `holochain_service`.
+- Fix: Use uuid network seed for provisioned cell, instead of system timestamp.
 
 ## [0.7.5] - 2025-01-10
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "network:android": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri android dev\" \"npm run tauri dev\"",
     "start:android:holochain_bundled": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri android dev -- --features holochain_bundled\"",
     "start:android:holochain_service": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri android dev -- --features holochain_service\"",
-    "start:desktop": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri dev\"",
+    "start:desktop": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri dev -- --features holochain_bundled\"",
     "launch": "concurrently-repeat \"npm run tauri dev\" $AGENTS",
     "tauri": "tauri",
     "setup:happ-release": "curl -L https://github.com/holochain-apps/volla-messages/releases/download/happ-v0.7.0-beta/relay.happ -o workdir/relay.happ"

--- a/src-tauri/src/builder/holochain_bundled.rs
+++ b/src-tauri/src/builder/holochain_bundled.rs
@@ -2,11 +2,11 @@ use crate::config::{APP_ID, HAPP_BUNDLE_BYTES};
 use holochain_types::prelude::AppBundle;
 use lair_keystore::dependencies::sodoken::{BufRead, BufWrite};
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Builder, EventLoopMessage, Listener, Manager, Runtime};
 use tauri_plugin_holochain::{
     GossipArcClamp, HolochainExt, HolochainPluginConfig, WANNetworkConfig,
 };
+use uuid::Uuid;
 
 const SIGNAL_URL: &'static str = "wss://sbd.holo.host";
 const BOOTSTRAP_URL: &'static str = "https://bootstrap-0.infra.holochain.org";
@@ -108,11 +108,6 @@ async fn setup<R: Runtime>(handle: AppHandle<R>) -> anyhow::Result<()> {
         .find(|app| app.installed_app_id.as_str().eq(APP_ID))
         .is_none()
     {
-        // we do this because we don't want to join everybody into the same dht!
-        let random_seed = format!(
-            "{}",
-            SystemTime::now().duration_since(UNIX_EPOCH)?.as_micros()
-        );
         handle
             .holochain()?
             .install_app(
@@ -120,7 +115,8 @@ async fn setup<R: Runtime>(handle: AppHandle<R>) -> anyhow::Result<()> {
                 happ_bundle()?,
                 None,
                 None,
-                Some(random_seed),
+                // Generate a random network seed so every user has their own private DHT for storing contacts
+                Some(Uuid::new_v4().to_string()),
             )
             .await?;
     } else {


### PR DESCRIPTION
### Summary
Ensure that the network seed of the provisioned cell is always unique, by using a uuid, not a system timestamp which could theoretically collide

### TODO:
- [x] CHANGELOG updated