### PR TITLE
Remove messages from store upon closing a conversation

### DIFF
--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -231,6 +231,8 @@
     clearTimeout(configTimeout);
     clearTimeout(messageTimeout);
 
+    conversationMessageStore.cleanupOlderMessages($page.params.id, 20);
+
     conversationContainerRef.removeEventListener("scroll", handleScroll);
 
     window.removeEventListener("resize", debouncedHandleResize);

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -231,7 +231,7 @@
     clearTimeout(configTimeout);
     clearTimeout(messageTimeout);
 
-    conversationMessageStore.cleanupOlderMessages($page.params.id, 20);
+    conversationMessageStore.deleteMessagesFromStore($page.params.id, 20);
 
     conversationContainerRef.removeEventListener("scroll", handleScroll);
 

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -51,7 +51,7 @@ export interface ConversationMessageStore extends GenericKeyKeyValueStore<Messag
   ) => Promise<number>;
   sendMessage: (key1: CellIdB64, content: string, files: LocalFile[]) => Promise<void>;
   handleMessageSignalReceived: (key1: CellIdB64, signal: MessageSignal) => Promise<void>;
-  cleanupOlderMessages: (key1: CellIdB64, keepLastN: number) => void;
+  deleteMessagesFromStore: (key1: CellIdB64, keepLastN: number) => void;
 }
 
 export function createConversationMessageStore(
@@ -452,7 +452,7 @@ export function createConversationMessageStore(
    * @param keepLastN
    */
 
-  function cleanupOlderMessages(key1: CellIdB64, keepLastN: number = 1) {
+  function deleteMessagesFromStore(key1: CellIdB64, keepLastN: number = 1) {
     messages.update((current) => {
       const conversationMessages = current[key1];
       if (!conversationMessages) return current;
@@ -473,7 +473,7 @@ export function createConversationMessageStore(
     loadMessagesInCurrentBucketTargetCount,
     loadMessagesInPreviousBucketTargetCount,
     sendMessage,
-    cleanupOlderMessages,
+    deleteMessagesFromStore,
     handleMessageSignalReceived,
     subscribe,
   };

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -51,6 +51,7 @@ export interface ConversationMessageStore extends GenericKeyKeyValueStore<Messag
   ) => Promise<number>;
   sendMessage: (key1: CellIdB64, content: string, files: LocalFile[]) => Promise<void>;
   handleMessageSignalReceived: (key1: CellIdB64, signal: MessageSignal) => Promise<void>;
+  cleanupOlderMessages: (key1: CellIdB64, keepLastN: number) => void;
 }
 
 export function createConversationMessageStore(
@@ -443,12 +444,41 @@ export function createConversationMessageStore(
     };
   }
 
+  /**
+   * Function for cleaning up older messages upon closing a conversation
+   * Reduces the number of messages stored in memory to keep the app performant
+   *
+   * @param key1
+   * @param keepLastN
+   */
+
+  function cleanupOlderMessages(key1: CellIdB64, keepLastN: number = 1) {
+    messages.update((current) => {
+      const conversationMessages = current[key1];
+      console.log("cleanupOlderMessages", conversationMessages);
+      if (!conversationMessages) return current;
+
+      const sorted = Object.entries(conversationMessages).sort(
+        ([, a], [, b]) => b.timestamp - a.timestamp,
+      );
+
+      const toKeep = sorted.slice(0, keepLastN);
+      console.log("cleanupOlderMessages toKeep", toKeep);
+
+      return {
+        ...current,
+        [key1]: Object.fromEntries(toKeep),
+      };
+    });
+  }
+
   return {
     ...messages,
     initialize,
     loadMessagesInCurrentBucketTargetCount,
     loadMessagesInPreviousBucketTargetCount,
     sendMessage,
+    cleanupOlderMessages,
     handleMessageSignalReceived,
     subscribe,
   };

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -455,16 +455,11 @@ export function createConversationMessageStore(
   function cleanupOlderMessages(key1: CellIdB64, keepLastN: number = 1) {
     messages.update((current) => {
       const conversationMessages = current[key1];
-      console.log("cleanupOlderMessages", conversationMessages);
       if (!conversationMessages) return current;
-
       const sorted = Object.entries(conversationMessages).sort(
         ([, a], [, b]) => b.timestamp - a.timestamp,
       );
-
       const toKeep = sorted.slice(0, keepLastN);
-      console.log("cleanupOlderMessages toKeep", toKeep);
-
       return {
         ...current,
         [key1]: Object.fromEntries(toKeep),


### PR DESCRIPTION
Partially Resolves #494

- Its more of a workaround for #494, and will not get merged to develop. We can consider it for the build we planned for beta users.
- Adds cleanup of messages stored in the store when closing a conversation, retaining only N messages.
- Addresses the issue of Svelte stores growing in size over time, which caused the app to crash and was previously fixed by clearing the cache. More details are provided in [this comment](https://github.com/holochain-apps/volla-messages/issues/494#issuecomment-2627447652).

TODO:

- [x] Cleanup messages from store upon closing a conversation
