### PR TITLE
Backport/508

### DIFF
--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -118,15 +118,17 @@ jobs:
 
       - name: Build android AAB
         run: |
+          cargo clean
           nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab --target aarch64 --target i686 --target x86_64"
 
       - name: Build android APKs
         run: |
+          cargo clean
           nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --target i686 --target x86_64"
 
       - uses: AButler/upload-release-assets@v3.0
         with:
-          files: src-tauri/gen/android/app/build/outputs/apk/*/release/app-*
+          files: "src-tauri/gen/android/app/build/outputs/apk/*/release/app-*;src-tauri/gen/android/app/build/outputs/**/*.aab"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-id: ${{ needs.create-release.outputs.releaseId }}
 

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -118,31 +118,11 @@ jobs:
 
       - name: Build android AAB
         run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab"
 
-      - name: Build android APK (aarch64)
+      - name: Build android APKs
         run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
-
-      - name: Build android APK (i684)
-        run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target i686 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
-      
-      - name: Build android APK (x86_64)
-        run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target x86_64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
-
-      - name: Rename android APKs
-        run: |
-          sudo apt install rename
-
-          # Rename apk to include the feature build label
-          find src-tauri/gen/android/app/build/outputs/apk/*/release -type f -name "*.apk" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
-          find src-tauri/gen/android/app/build/outputs -type f -name "*.aab" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --target i686 --target x86_64"
 
       - uses: AButler/upload-release-assets@v3.0
         with:

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -116,9 +116,33 @@ jobs:
           echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
           echo "storePassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
 
-      - name: Build android APKs
+      - name: Build android AAB
         run: |
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --target i686 --target x86_64"
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+
+      - name: Build android APK (aarch64)
+        run: |
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+
+      - name: Build android APK (i684)
+        run: |
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target i686 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+      
+      - name: Build android APK (x86_64)
+        run: |
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target x86_64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+
+      - name: Rename android APKs
+        run: |
+          sudo apt install rename
+
+          # Rename apk to include the feature build label
+          find src-tauri/gen/android/app/build/outputs/apk/*/release -type f -name "*.apk" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
+          find src-tauri/gen/android/app/build/outputs -type f -name "*.aab" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
 
       - uses: AButler/upload-release-assets@v3.0
         with:

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -18,7 +18,12 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: "Volla Messages ${{ github.ref_name }}"
-          body: "See the assets to download this version and install."
+          body: |
+            See the assets to download this version and install.
+
+            Android builds are distinguished as either 'rich' or 'lite':
+            - The 'rich' build includes a bundled holochain conductor. It can be used on any Android device.
+            - The 'lite' build relies on the holochain conductor provided by the [Android Service Runtime app](https://github.com/holochain/android-service-runtime),. The Android Service Runtime app can be installed on any Android device, and will be preinstalled with Volla OS.
           prerelease: true
           draft: true
 
@@ -70,7 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           releaseId: ${{ needs.create-release.outputs.releaseId }}
-          args: --verbose
+          args: --verbose --features holochain_bundled
 
   release-tauri-app-android:
     permissions: write-all
@@ -79,6 +84,14 @@ jobs:
       - release-tauri-app-linux
       - create-release
     runs-on: 'ubuntu-22.04' 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - feature: 'holochain_service'
+            label: lite
+          - feature: 'holochain_bundled'
+            label: rich
     steps:
       - uses: actions/checkout@v3
 
@@ -118,11 +131,31 @@ jobs:
 
       - name: Build android AAB
         run: |
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab"
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
 
-      - name: Build android APKs
+      - name: Build android APK (aarch64)
         run: |
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --target i686 --target x86_64"
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+
+      - name: Build android APK (i684)
+        run: |
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target i686 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+      
+      - name: Build android APK (x86_64)
+        run: |
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target x86_64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+
+      - name: Rename android APKs
+        run: |
+          sudo apt install rename
+
+          # Rename apk to include the feature build label
+          find src-tauri/gen/android/app/build/outputs/apk/*/release -type f -name "*.apk" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
+          find src-tauri/gen/android/app/build/outputs -type f -name "*.aab" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
 
       - uses: AButler/upload-release-assets@v3.0
         with:
@@ -136,6 +169,8 @@ jobs:
     environment: Relay Release
     runs-on: windows-latest
     steps:
+      - run: git config --system core.longpaths true
+
       - uses: actions/checkout@v3
 
       - name: setup node
@@ -164,7 +199,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --verbose
+          args: --verbose --features holochain_bundled
 
       - name: Sign the App
         run: |
@@ -192,7 +227,7 @@ jobs:
           CertUtil -hashfile $BUNDLE_OUT_PATH_2 SHA256
 
           # Code sign the output bundles via azure key vault, following these instructions:
-          # https://melatonin.dev/blog/how-to-code-sign-windows-installers-with-an-ev-cert-on-github-actions/          dotnet tool install --global AzureSignTool
+          # https://melatonin.dev/blog/how-to-code-sign-windows-installers-with-an-ev-cert-on-github-actions/
           dotnet tool install --global AzureSignTool
           AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v $BUNDLE_OUT_PATH_1
           AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v $BUNDLE_OUT_PATH_2
@@ -262,4 +297,4 @@ jobs:
 
         with:
           releaseId: ${{ needs.create-release.outputs.releaseId }}
-          args: --verbose
+          args: --verbose --features holochain_bundled

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -126,9 +126,17 @@ jobs:
           cargo clean
           nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --target i686 --target x86_64"
 
-      - uses: AButler/upload-release-assets@v3.0
+      - name: Upload Android APK  
+        uses: AButler/upload-release-assets@v3.0
         with:
-          files: "src-tauri/gen/android/app/build/outputs/apk/*/release/app-*;src-tauri/gen/android/app/build/outputs/**/*.aab"
+          files: src-tauri/gen/android/app/build/outputs/apk/*/release/app-*
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-id: ${{ needs.create-release.outputs.releaseId }}
+
+      - name: Upload Android AAB  
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: src-tauri/gen/android/app/build/outputs/bundle/**/*.aab
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-id: ${{ needs.create-release.outputs.releaseId }}
 

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -116,27 +116,13 @@ jobs:
           echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
           echo "storePassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
 
-      - name: Build android AAB
-        run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab --target aarch64 --target i686 --target x86_64"
-
       - name: Build android APKs
         run: |
-          cargo clean
           nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --target i686 --target x86_64"
 
-      - name: Upload Android APK  
-        uses: AButler/upload-release-assets@v3.0
+      - uses: AButler/upload-release-assets@v3.0
         with:
           files: src-tauri/gen/android/app/build/outputs/apk/*/release/app-*
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-id: ${{ needs.create-release.outputs.releaseId }}
-
-      - name: Upload Android AAB  
-        uses: AButler/upload-release-assets@v3.0
-        with:
-          files: src-tauri/gen/android/app/build/outputs/bundle/**/*.aab
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-id: ${{ needs.create-release.outputs.releaseId }}
 

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -18,12 +18,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: "Volla Messages ${{ github.ref_name }}"
-          body: |
-            See the assets to download this version and install.
-
-            Android builds are distinguished as either 'rich' or 'lite':
-            - The 'rich' build includes a bundled holochain conductor. It can be used on any Android device.
-            - The 'lite' build relies on the holochain conductor provided by the [Android Service Runtime app](https://github.com/holochain/android-service-runtime),. The Android Service Runtime app can be installed on any Android device, and will be preinstalled with Volla OS.
+          body: "See the assets to download this version and install."
           prerelease: true
           draft: true
 
@@ -75,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           releaseId: ${{ needs.create-release.outputs.releaseId }}
-          args: --verbose --features holochain_bundled
+          args: --verbose
 
   release-tauri-app-android:
     permissions: write-all
@@ -84,14 +79,6 @@ jobs:
       - release-tauri-app-linux
       - create-release
     runs-on: 'ubuntu-22.04' 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - feature: 'holochain_service'
-            label: lite
-          - feature: 'holochain_bundled'
-            label: rich
     steps:
       - uses: actions/checkout@v3
 
@@ -131,31 +118,11 @@ jobs:
 
       - name: Build android AAB
         run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab"
 
-      - name: Build android APK (aarch64)
+      - name: Build android APKs
         run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
-
-      - name: Build android APK (i684)
-        run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target i686 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
-      
-      - name: Build android APK (x86_64)
-        run: |
-          cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target x86_64 --features ${{ matrix.feature }} --config src-tauri/tauri.${{ matrix.feature }}.conf.json"
-
-      - name: Rename android APKs
-        run: |
-          sudo apt install rename
-
-          # Rename apk to include the feature build label
-          find src-tauri/gen/android/app/build/outputs/apk/*/release -type f -name "*.apk" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
-          find src-tauri/gen/android/app/build/outputs -type f -name "*.aab" -exec rename -v 's/release\/app/release\/app-${{ matrix.label }}/' {} \;
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --apk --split-per-abi --target aarch64 --target i686 --target x86_64"
 
       - uses: AButler/upload-release-assets@v3.0
         with:
@@ -169,8 +136,6 @@ jobs:
     environment: Relay Release
     runs-on: windows-latest
     steps:
-      - run: git config --system core.longpaths true
-
       - uses: actions/checkout@v3
 
       - name: setup node
@@ -199,7 +164,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --verbose --features holochain_bundled
+          args: --verbose
 
       - name: Sign the App
         run: |
@@ -227,7 +192,7 @@ jobs:
           CertUtil -hashfile $BUNDLE_OUT_PATH_2 SHA256
 
           # Code sign the output bundles via azure key vault, following these instructions:
-          # https://melatonin.dev/blog/how-to-code-sign-windows-installers-with-an-ev-cert-on-github-actions/
+          # https://melatonin.dev/blog/how-to-code-sign-windows-installers-with-an-ev-cert-on-github-actions/          dotnet tool install --global AzureSignTool
           dotnet tool install --global AzureSignTool
           AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v $BUNDLE_OUT_PATH_1
           AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v $BUNDLE_OUT_PATH_2
@@ -297,4 +262,4 @@ jobs:
 
         with:
           releaseId: ${{ needs.create-release.outputs.releaseId }}
-          args: --verbose --features holochain_bundled
+          args: --verbose

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Build android AAB
         run: |
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab"
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri android build -- --aab --target aarch64 --target i686 --target x86_64"
 
       - name: Build android APKs
         run: |


### PR DESCRIPTION
Backport #508 

We didn't have the `foreground-service` backported to `develop-0.3`, feature flags like holochain_bundled won't work. 

So, instead of cherry-picking, I manually added the command.