### PR TITLE
build: change app name and package id for lite & rich builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Added npm command to run app locally using production `.happ`.
-- The build features `holochain_bundled` and `holochain_service` now have different android package names, which allows them to both be installed on the same device (and thus prevent an install of one to replace the other). The build feature `holochain_bundled` now has a different app name of "Volla Messages (Standalone)" to distinguish it for the user.
+- CI release builds with the feature `holochain_service` now have a different android package name `org.volla.messages.service`. CI release builds with the feature `holochain_bundled` now have a different app name of "Volla Messages (Standalone)".
 
 ## [0.7.6] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- The build features `holochain_bundled` and `holochain_service` now have different android package names, which allows them to both be installed on the same device (and thus prevent an install of one to replace the other). The build feature `holochain_bundled` now has a different app name of "Volla Messages (Standalone)" to distinguish it for the user.
+
 ## [0.7.6] - 2025-03-21
 
 - Fix: Display "unconfirmed" label for contacts that have not yet joined their private conversation.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,5 @@
 {
-  "productName": "Volla Messages",
   "version": "0.7.6",
-  "identifier": "com.volla.messages",
   "build": {
     "beforeBuildCommand": "npm run build -w ui",
     "devUrl": "http://localhost:1420",

--- a/src-tauri/tauri.holochain_bundled.conf.json
+++ b/src-tauri/tauri.holochain_bundled.conf.json
@@ -1,4 +1,6 @@
 {
+  "productName": "Volla Messages (Standalone)",
+  "identifier": "com.volla.messages.standalone",
   "bundle": {
     "icon": [
       "icons/squiggle/32x32.png",

--- a/src-tauri/tauri.holochain_bundled.conf.json
+++ b/src-tauri/tauri.holochain_bundled.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Volla Messages (Standalone)",
-  "identifier": "com.volla.messages.standalone",
+  "identifier": "com.volla.messages",
   "bundle": {
     "icon": [
       "icons/squiggle/32x32.png",

--- a/src-tauri/tauri.holochain_service.conf.json
+++ b/src-tauri/tauri.holochain_service.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Volla Messages",
-  "identifier": "com.volla.messages",
+  "identifier": "com.volla.messages.service",
   "bundle": {
     "icon": [
       "icons/colon/32x32.png",

--- a/src-tauri/tauri.holochain_service.conf.json
+++ b/src-tauri/tauri.holochain_service.conf.json
@@ -1,4 +1,6 @@
 {
+  "productName": "Volla Messages",
+  "identifier": "com.volla.messages",
   "bundle": {
     "icon": [
       "icons/colon/32x32.png",


### PR DESCRIPTION
### Summary
Modify the tauri config so the "lite" and "rich" builds have a different app name and package id. 

This ensures a user cannot install one build type as an update to a different build type, which would result in unexpected behavior.

### TODO:
- [x] CHANGELOG updated