### PR TITLE
chore: npm command to run locally using production happ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added npm command to run app locally using production `.happ`.
+
 ## [0.7.6] - 2025-03-21
 
 - Fix: Display "unconfirmed" label for contacts that have not yet joined their private conversation.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,22 @@ Built with Holochain + Tauri + SvelteKit + TailWind + Skeleton
 
 Volla Messages is a Holochain application deployed using [p2pShipyard](https://darksoil.studio/p2p-shipyard/) for Mobile and Desktop.  
 
-### Dev Testing Desktop only
+### Run on desktop
 
 ```bash
 nix develop
 npm install
-npm run start
+npm run start:desktop
+```
+
+### Run on desktop with production happ
+
+To run locally using the *production* happ that is included in CI release builds, run:
+
+```bash
+nix develop
+npm install
+npm run start:desktop:happ-release
 ```
 
 ### Building and Testing on Android

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start:android:holochain_bundled": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri android dev -- --features holochain_bundled\"",
     "start:android:holochain_service": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri android dev -- --features holochain_service\"",
     "start:desktop": "npm run build:happ && BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri dev -- --features holochain_bundled\"",
+    "start:desktop:happ-release": "npm run setup:happ-release && BOOTSTRAP_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri dev -- --features holochain_bundled\"",
     "launch": "concurrently-repeat \"npm run tauri dev -- --features holochain_bundled\" $AGENTS",
     "tauri": "tauri",
     "setup:happ-release": "curl -L https://github.com/holochain-apps/volla-messages/releases/download/happ-v0.7.0-beta/relay.happ -o workdir/relay.happ"


### PR DESCRIPTION
### Summary
Add npm command `npm run start:desktop:happ-release` to download the production happ from github releases, then run the app using it.

### TODO:
- [x] CHANGELOG updated