### PR TITLE
fix hc-spin run context

### DIFF
--- a/ui/src/hooks.client.ts
+++ b/ui/src/hooks.client.ts
@@ -6,7 +6,7 @@ export const handleError: HandleClientError = async ({ error, event, status, mes
   console.error(`Error ID: ${errorId}`, error, event, status, message);
 
   return {
-    message: `An error occurred: ${message}`,
+    message: `An error occurred: ${message} ${error}`,
     errorId,
   };
 };

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -34,10 +34,15 @@ export function shareText(text: string): Promise<void> {
  * @returns
  */
 export function copyToClipboard(text: string): Promise<void> {
+
   const normalized = text.trim();
   if (normalized.length === 0) throw Error("Text is empty");
 
-  return writeText(text);
+  if (getPlatform() == "non-tauri") {
+    return navigator.clipboard.writeText(text)
+  } else {
+    return writeText(text);
+  }
 }
 
 /**
@@ -61,13 +66,22 @@ export async function enqueueNotification(title: string, body: string) {
   }
 }
 
+export function getPlatform(): string {
+  let currentPlatform = "non-tauri"
+  try {
+    currentPlatform = platform();
+  }  catch(e) {
+  }
+  return currentPlatform
+}
+
 /**
  * Is app running on mobile?
  *
  * @returns
  */
 export function isMobile(): boolean {
-  const val = platform();
+  const val = getPlatform();
   return val === "android" || val === "ios";
 }
 

--- a/ui/src/store/ScanStore.ts
+++ b/ui/src/store/ScanStore.ts
@@ -1,7 +1,7 @@
 import { derived, get, writable, type Invalidator, type Subscriber, type Unsubscriber } from "svelte/store";
-import { platform } from "@tauri-apps/plugin-os";
 import { goto } from "$app/navigation";
 import { page } from "$app/stores";
+import { getPlatform } from "$lib/utils";
 
 // tarui-plugin-barcode-scanner launches the scanner as a fullscreen View
 // In order to display our overlay upon it, we must have a fully transparent background.
@@ -27,8 +27,8 @@ export interface ScanStore {
 
 
 function  createScanStore() {
-  const currentPlatform = platform();
-  const isSupported = writable(
+ let currentPlatform = getPlatform()
+ const isSupported = writable(
     Boolean(currentPlatform === "ios" || currentPlatform === "android"),
   );
   const value = writable<string | null>(null);


### PR DESCRIPTION
### Summary

- adds fixes so that `npm run spin` now works again (handles problems with clipboard copy and platform detection)

### TODO:
- [ ] CHANGELOG updated