### PR TITLE
feature: adds in low-level user-network settings and test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10424,6 +10424,7 @@ dependencies = [
  "holochain_types",
  "lair_keystore",
  "log",
+ "serde",
  "serde_json",
  "tauri",
  "tauri-build",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
 
     "start:desktop": "cp -f src-tauri/tauri.desktop.conf.json src-tauri/tauri.conf.json && npm run build:happ && BOOTSTRAP_PORT=$(port) INTERNAL_IP=$(internal-ip --ipv4) concurrently -k \"npm run local-services\" \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri dev -- --features holochain_bundled\"",
     "start:desktop:happ-release": "npm run setup:happ-release && concurrently -k \"UI_PORT=1420 npm run -w ui start\" \"npm run tauri dev -- --release --features holochain_bundled\"",
-    
+
+    "build:desktop:happ-release": "npm run tauri build -- --verbose --features holochain_bundled",
+
     "launch": "concurrently-repeat \"npm run tauri dev -- --features holochain_bundled\" $AGENTS",
     "tauri": "tauri",
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ app_dirs2 = "2.5.5"
 tempdir = "0.3.7"
 anyhow = "1"
 serde_json = "1"
+serde = "1"
 uuid = { version = "1.12.0", features = ["v4", "fast-rng"] }
 base64ct = "=1.7.3"
 

--- a/src-tauri/src/builder/holochain_bundled.rs
+++ b/src-tauri/src/builder/holochain_bundled.rs
@@ -1,19 +1,26 @@
 use crate::config::{APP_ID, HAPP_BUNDLE_BYTES};
 use holochain_types::prelude::AppBundle;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::path::PathBuf;
 use tauri::{AppHandle, Builder, EventLoopMessage, Listener, Manager, Runtime};
-use tauri_plugin_holochain::{HolochainExt, HolochainPluginConfig, vec_to_locked};
-use tauri_plugin_holochain::NetworkConfig;
+use tauri_plugin_holochain::{vec_to_locked, HolochainExt, HolochainPluginConfig, NetworkConfig};
+use url2::Url2;
 use uuid::Uuid;
-use serde_json::json;
 
-pub const SIGNAL_URL: &'static str = "wss://dev-test-bootstrap2.holochain.org/";
+pub const DEFAULT_SIGNAL_URL: &'static str = "wss://dev-test-bootstrap2.holochain.org/";
 
-pub const BOOTSTRAP_URL: &'static str = "https://dev-test-bootstrap2.holochain.org/";
+pub const DEFAULT_BOOTSTRAP_URL: &'static str = "https://dev-test-bootstrap2.holochain.org/";
 
-pub static ICE_URLS: &'static [&str] = &[
-    "stun://stun.l.google.com:19302"
-];
+pub static DEFAULT_ICE_URLS: &'static [&str] = &["stun://stun.l.google.com:19302"];
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UserNetworkConfig {
+    bootstrap_url: Option<Url2>,
+    signal_url: Option<Url2>,
+    ice_servers: Option<Vec<Url2>>,
+}
 
 pub fn happ_bundle() -> anyhow::Result<AppBundle> {
     let bundle = AppBundle::decode(HAPP_BUNDLE_BYTES)?;
@@ -27,9 +34,14 @@ where
     >>::WindowBuilder: std::marker::Send,
 {
     builder
+        .invoke_handler(tauri::generate_handler![
+            default_user_network_config,
+            get_user_network_config,
+            set_user_network_config
+        ])
         .plugin(tauri_plugin_holochain::async_init(
             vec_to_locked(vec![]),
-            HolochainPluginConfig::new(holochain_dir(), network_config())
+            HolochainPluginConfig::new(holochain_dir(), network_config()),
         ))
         .setup(|app| {
             let handle = app.handle().clone();
@@ -126,13 +138,31 @@ async fn setup<R: Runtime>(handle: AppHandle<R>) -> anyhow::Result<()> {
     }
     Ok(())
 }
+
 fn network_config() -> NetworkConfig {
     let mut config = NetworkConfig::default();
-    config.signal_url = url2::url2!("{}", SIGNAL_URL);
-    config.bootstrap_url = url2::url2!("{}", BOOTSTRAP_URL);
-    config.webrtc_config = Some(json!({ "iceServers": [ { "urls": ICE_URLS }]}));
+    if let Ok(Some(user_network_config)) = read_user_network_config() {
+        if let Some(bootstrap_url) = user_network_config.bootstrap_url {
+            config.bootstrap_url = bootstrap_url;
+        }
+        if let Some(signal_url) = user_network_config.signal_url {
+            config.signal_url = signal_url;
+        }
+        if let Some(ice_servers) = user_network_config.ice_servers {
+            config.webrtc_config = Some(json!({ "iceServers": [ { "urls": ice_servers }]}));
+        }
+    } else {
+        config.signal_url = url2::url2!("{}", DEFAULT_SIGNAL_URL);
+        config.bootstrap_url = url2::url2!("{}", DEFAULT_BOOTSTRAP_URL);
+        config.webrtc_config = Some(json!({ "iceServers": [ { "urls": DEFAULT_ICE_URLS }]}));
+    }
+    // // Don't hold any slice of the DHT in mobile
+    // if cfg!(mobile) {
+    //     config.target_arc_factor = 0;
+    // }
     config
 }
+
 fn holochain_dir() -> PathBuf {
     if tauri::is_dev() {
         #[cfg(target_os = "android")]
@@ -183,4 +213,73 @@ fn get_version() -> String {
     }
     let v: Vec<&str> = semver.split(".").collect();
     return format!("{}", v[0]);
+}
+
+#[tauri::command]
+pub fn set_user_network_config<R: Runtime>(
+    app: AppHandle<R>,
+    bootstrap_url: Url2,
+    signal_url: Url2,
+    ice_servers: Vec<Url2>,
+) -> Result<(), String> {
+    let config = UserNetworkConfig {
+        bootstrap_url: Some(bootstrap_url),
+        signal_url: Some(signal_url),
+        ice_servers: Some(ice_servers),
+    };
+    write_user_network_config(config).map_err(|e| e.to_string())?;
+
+    app.restart();
+    // Ok(())
+}
+
+#[tauri::command]
+fn get_user_network_config() -> Result<Option<UserNetworkConfig>, String> {
+    let config = read_user_network_config().map_err(|e| e.to_string())?;
+    Ok(config)
+}
+
+#[tauri::command]
+fn default_user_network_config() -> UserNetworkConfig {
+    let config = UserNetworkConfig {
+        bootstrap_url: Some(url2::url2!("{}", DEFAULT_BOOTSTRAP_URL)),
+        signal_url: Some(url2::url2!("{}", DEFAULT_SIGNAL_URL)),
+        ice_servers: Some(
+            DEFAULT_ICE_URLS
+                .into_iter()
+                .map(|url| url2::url2!("{}", url))
+                .collect(),
+        ),
+    };
+    config
+}
+
+fn user_network_config_path() -> PathBuf {
+    app_dirs2::app_root(
+        app_dirs2::AppDataType::UserData,
+        &app_dirs2::AppInfo {
+            name: APP_ID,
+            author: std::env!("CARGO_PKG_AUTHORS"),
+        },
+    )
+    .expect("Could not get app root")
+    .join("user-network-config.json")
+}
+
+fn write_user_network_config(config: UserNetworkConfig) -> anyhow::Result<()> {
+    let contents = serde_json::to_string(&config)?;
+
+    std::fs::write(user_network_config_path(), contents)?;
+    Ok(())
+}
+
+fn read_user_network_config() -> anyhow::Result<Option<UserNetworkConfig>> {
+    let path = user_network_config_path();
+    if !std::fs::exists(&path)? {
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(path)?;
+
+    let config: UserNetworkConfig = serde_json::from_str(contents.as_str())?;
+    Ok(Some(config))
 }

--- a/ui/src/routes/account/+page.svelte
+++ b/ui/src/routes/account/+page.svelte
@@ -11,6 +11,14 @@
   import ButtonIconBare from "$lib/ButtonIconBare.svelte";
   import InputImageAvatar from "$lib/InputImageAvatar.svelte";
   import { type CellProfileStore, type ProfileStore } from "$store/ProfileStore";
+  import { invoke } from "@tauri-apps/api/core";
+  import Button from "$lib/Button.svelte";
+
+  type UserNetworkSettings = {
+    bootstrapUrl: string | undefined;
+    signalUrl: string | undefined;
+    iceServers: Array<string> | undefined;
+  };
 
   const profileStore = getContext<{ getStore: () => ProfileStore }>("profileStore").getStore();
   const provisionedRelayCellProfileStore = getContext<{
@@ -41,6 +49,28 @@
     }
     saving = false;
     editingName = false;
+  }
+  async function setUserNetworkConfig(settings: UserNetworkSettings) {
+    return invoke("set_user_network_config", settings);
+  }
+  async function getUserNetworkConfig(): Promise<UserNetworkSettings> {
+    return invoke("get_user_network_config");
+  }
+  async function defaultUserNetworkConfig(): Promise<UserNetworkSettings> {
+    return invoke("default_user_network_config");
+  }
+
+  // TODO: remove this and create actual UI for updating the setting along with notification
+  // that doing so will restart the app.
+  async function testUpdateSettings() {
+    let currentSettings: UserNetworkSettings | null = await getUserNetworkConfig();
+    if (currentSettings === null) {
+      console.log("no user settings have been set, getting defaults");
+      currentSettings = await defaultUserNetworkConfig();
+      console.log("setting defaults as custom setting for testing purposes");
+      await setUserNetworkConfig(currentSettings);
+    }
+    console.log(JSON.stringify(currentSettings));
   }
 </script>
 
@@ -98,5 +128,8 @@
       copyLabel={$t("common.copy_your_contact_code")}
       shareLabel={$t("common.share_your_contact_code")}
     />
+    <Button style="margin-top:5px" on:click={async () => await testUpdateSettings()}
+      >Settings</Button
+    >
   </div>
 </div>


### PR DESCRIPTION
### Summary

Adds the ability for the end-user to set all the of the network server URLs a the tauri level and creates invokable commands to retrieve default values, and get & set current values.

Notes:
- Default values are compiled into the app, and are used if there is no user saved values.
- Values saved by the user are placed in the appropriate application data folders for each platform.
- You can determine values has ever been set by invoking get_user_network_config and seeing if the value returned is `null`
- Upon saving values the app is restarted so that they will take effect
- This PR does NOT implement 

### TODO:
- [ ] CHANGELOG updated