### PR TITLE
The bootstrap/signal/stun links are update now

### DIFF
--- a/src-tauri/src/builder/holochain_bundled.rs
+++ b/src-tauri/src/builder/holochain_bundled.rs
@@ -7,12 +7,12 @@ use tauri_plugin_holochain::NetworkConfig;
 use uuid::Uuid;
 use serde_json::json;
 
-pub const SIGNAL_URL: &'static str = "wss://dev-test-bootstrap2.holochain.org/";
+pub const SIGNAL_URL: &'static str = "https://relay.volla.tech/";
 
-pub const BOOTSTRAP_URL: &'static str = "https://dev-test-bootstrap2.holochain.org/";
+pub const BOOTSTRAP_URL: &'static str = "https://relay.volla.tech/";
 
 pub static ICE_URLS: &'static [&str] = &[
-    "stun://stun.l.google.com:19302"
+    "stun://stun.nextcloud.com:443"
 ];
 
 pub fn happ_bundle() -> anyhow::Result<AppBundle> {


### PR DESCRIPTION
### Summary
The nextcloud stun server added.
The bootstarap and signal url updated. 
### TODO:
- [ ] CHANGELOG updated