### PR TITLE
Chore/bump tauri plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9199,9 +9199,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-holochain-service-client"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79089b2b48b46c7c5a49a55bd5dae425b90b1dce8322061720d8d9720a1fcfd7"
+checksum = "b1092717880a96a346a4686356195f82fe698bfe283b6ae3ea047ed9517007f7"
 dependencies = [
  "bytes",
  "holochain-conductor-runtime-types-ffi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10415,7 +10415,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volla_messages"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volla_messages",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "private": true,
   "workspaces": [
     "ui"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volla_messages"
-version = "0.9.0"
+version = "0.9.2"
 description = "Volla Messages"
 authors = ["Tibet Sprague", "Eric Harris-Braun"]
 license = ""

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.2.0", default-features = false , features = [] }
 tauri = { version = "2.5.1", features = ["devtools"] }
 tauri-runtime = {version = "2.6.0", optional = true}
 tauri-plugin-holochain = { git = "https://github.com/darksoil-studio/tauri-plugin-holochain", branch = "main-0.5", optional = true }
-tauri-plugin-holochain-service-client = { version = "0.2.2", optional = true }
+tauri-plugin-holochain-service-client = { version = "0.2.3", optional = true }
 
 # datachanel webrtc backend
 holochain = "0.5.6"

--- a/src-tauri/tauri.desktop.conf.json
+++ b/src-tauri/tauri.desktop.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "Volla Messages",
   "identifier": "com.volla.messages.bundled",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "build": {
     "beforeBuildCommand": "npm run build -w ui",
     "devUrl": "http://localhost:1420",

--- a/src-tauri/tauri.mobile.holochain_bundled.conf.json
+++ b/src-tauri/tauri.mobile.holochain_bundled.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "Volla Messages (Standalone)",
   "identifier": "com.volla.messages.bundled",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "build": {
     "beforeBuildCommand": "npm run build -w ui",
     "devUrl": "http://localhost:1420",

--- a/src-tauri/tauri.mobile.holochain_service.conf.json
+++ b/src-tauri/tauri.mobile.holochain_service.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "Volla Messages",
   "identifier": "com.volla.messages",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "build": {
     "beforeBuildCommand": "npm run build -w ui",
     "devUrl": "http://localhost:1420",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "private": true,
   "scripts": {
     "start": "vite --clearScreen false",


### PR DESCRIPTION
### Summary
Bump tauri-plugin-holochain-service-client to 0.2.3 for making the ASR v0.1.5 fixes visible to the Lite version and also create a new release for Volla-messages v0.9.2

### TODO:
- [ ] CHANGELOG updated