### PR TITLE
fix: update conversation summary to display image and file counts correctly

### DIFF
--- a/ui/src/routes/conversations/MessagePreview.svelte
+++ b/ui/src/routes/conversations/MessagePreview.svelte
@@ -7,21 +7,40 @@
 
   export let messageExtended: MessageExtended;
   export let cellIdB64: CellIdB64;
+
+  // Separate images from other files based on MIME type
+  $: imageFiles = messageExtended.message.images.filter((file) =>
+    file.file_type.startsWith("image/"),
+  );
+  $: otherFiles = messageExtended.message.images.filter(
+    (file) => !file.file_type.startsWith("image/"),
+  );
+  $: hasImages = imageFiles.length > 0;
+  $: hasFiles = otherFiles.length > 0;
 </script>
 
-<div class="flex items-start justify-start space-x-2 mt-1">
+<div class="mt-1 flex items-start justify-start space-x-2">
   <div class=" flex items-start justify-start space-x-1">
     <Avatar agentPubKeyB64={messageExtended.authorAgentPubKeyB64} {cellIdB64} size={14} />
-    <AgentNickname cellIdB64={cellIdB64} agentPubKeyB64={messageExtended.authorAgentPubKeyB64} />
+    <AgentNickname {cellIdB64} agentPubKeyB64={messageExtended.authorAgentPubKeyB64} />
   </div>
 
   <div>{@html DOMPurify.sanitize(messageExtended.message.content)}</div>
 
-  {#if messageExtended.message.images.length > 0}
+  {#if hasImages || hasFiles}
     <div class="text-secondary-400 italic">
-      ({$t("common.images", {
-        count: messageExtended.message.images.length,
-      })})
+      ({#if hasImages}
+        {$t("common.images", {
+          count: imageFiles.length,
+        })}
+      {/if}
+      {#if hasImages && hasFiles},
+      {/if}
+      {#if hasFiles}
+        {$t("common.files", {
+          count: otherFiles.length,
+        })}
+      {/if})
     </div>
   {/if}
 </div>

--- a/ui/src/translations/locales/bg.json
+++ b/ui/src/translations/locales/bg.json
@@ -27,6 +27,8 @@
   "first": "First",
   "first_name": "Първо име",
   "group_name": "Име на групата",
+  "images": "{{count}} {{count; 1:изображение; default:изображения;}}",
+  "files": "{{count}} {{count; 1:файл; default:файлове;}}",
   "invalid_contact_code": "Невалиден код за контакт",
   "join_conversation": "Участвайте в разговора",
   "jump_in": "Jump In",

--- a/ui/src/translations/locales/da.json
+++ b/ui/src/translations/locales/da.json
@@ -31,6 +31,7 @@
   "first_name": "Indtast fornavn",
   "group_name": "Gruppenavn",
   "images": "{{count}} {{count; 1:image; default:images;}}",
+  "files": "{{count}} {{count; 1:fil; default:filer;}}",
   "invalid_contact_code": "Ugyldig kode",
   "join_conversation": "Deltag i konversation",
   "jump_in": "Hop ind",

--- a/ui/src/translations/locales/de.json
+++ b/ui/src/translations/locales/de.json
@@ -54,6 +54,7 @@
   "group_name": "Gruppenname",
   "holochain_connect_error": "Error connecting to Holochain",
   "images": "{{count}} {{count; 1:image; default:images;}}",
+  "files": "{{count}} {{count; 1:Datei; default:Dateien;}}",
   "invalid_contact_code": "Ungültiger Kontakt-Code",
   "join_conversation": "An der Konversation teilnehmen",
   "jump_in": "Hineinspringen",

--- a/ui/src/translations/locales/en.json
+++ b/ui/src/translations/locales/en.json
@@ -54,6 +54,7 @@
   "group_name": "Group name",
   "holochain_connect_error": "Error connecting to Holochain",
   "images": "{{count}} {{count; 1:image; default:images;}}",
+  "files": "{{count}} {{count; 1:file; default:files;}}",
   "invalid_contact_code": "Invalid contact code",
   "join_conversation": "Join Conversation",
   "jump_in": "Jump In",

--- a/ui/src/translations/locales/es.json
+++ b/ui/src/translations/locales/es.json
@@ -27,6 +27,8 @@
   "first": "First",
   "first_name": "Nombre",
   "group_name": "Nombre del grupo",
+  "images": "{{count}} {{count; 1:imagen; default:imágenes;}}",
+  "files": "{{count}} {{count; 1:archivo; default:archivos;}}",
   "invalid_contact_code": "Código de contacto no válido",
   "join_conversation": "Participe en la conversación",
   "jump_in": "Jump In",

--- a/ui/src/translations/locales/fr.json
+++ b/ui/src/translations/locales/fr.json
@@ -27,6 +27,8 @@
   "first": "First",
   "first_name": "Prénom",
   "group_name": "Nom du groupe",
+  "images": "{{count}} {{count; 1:image; default:images;}}",
+  "files": "{{count}} {{count; 1:fichier; default:fichiers;}}",
   "invalid_contact_code": "Code de contact non valide",
   "join_conversation": "Participer à la conversation",
   "jump_in": "Jump In",

--- a/ui/src/translations/locales/it.json
+++ b/ui/src/translations/locales/it.json
@@ -27,6 +27,8 @@
   "first": "First",
   "first_name": "Nome",
   "group_name": "Nome del gruppo",
+  "images": "{{count}} {{count; 1:immagine; default:immagini;}}",
+  "files": "{{count}} {{count; 1:file; default:file;}}",
   "invalid_contact_code": "Codice di contatto non valido",
   "join_conversation": "Partecipare alla conversazione",
   "jump_in": "Jump In",

--- a/ui/src/translations/locales/nl.json
+++ b/ui/src/translations/locales/nl.json
@@ -32,6 +32,7 @@
   "group_name": "Groepsnaam",
   "holochain_connect_error": "Fout bij verbinding met Holochain",
   "images": "{{count}} {{count; 1:image; default:images;}}",
+  "files": "{{count}} {{count; 1:bestand; default:bestanden;}}",
   "invalid_contact_code": "Ongeldige contactcode",
   "join_conversation": "Neem deel aan het gesprek",
   "jump_in": "Stap in",

--- a/ui/src/translations/locales/no.json
+++ b/ui/src/translations/locales/no.json
@@ -31,6 +31,7 @@
   "first_name": "Skriv fornavn",
   "group_name": "Gruppenavn",
   "images": "{{count}} {{count; 1:image; default:images;}}",
+  "files": "{{count}} {{count; 1:fil; default:filer;}}",
   "invalid_contact_code": "Ugyldig kode",
   "join_conversation": "Delta i konversasjon",
   "jump_in": "Hopp inn",

--- a/ui/src/translations/locales/ro.json
+++ b/ui/src/translations/locales/ro.json
@@ -27,6 +27,8 @@
   "first": "În primul rând",
   "first_name": "Numele și prenumele",
   "group_name": "Numele grupului",
+  "images": "{{count}} {{count; 1:imagine; default:imagini;}}",
+  "files": "{{count}} {{count; 1:fișier; default:fișiere;}}",
   "invalid_contact_code": "Cod de contact invalid",
   "join_conversation": "Participați la conversație",
   "jump_in": "Jump In",

--- a/ui/src/translations/locales/sk.json
+++ b/ui/src/translations/locales/sk.json
@@ -27,6 +27,8 @@
   "first": "First",
   "first_name": "Krstné meno",
   "group_name": "Názov skupiny",
+  "images": "{{count}} {{count; 1:obrázok; default:obrázky;}}",
+  "files": "{{count}} {{count; 1:súbor; default:súbory;}}",
   "invalid_contact_code": "Neplatný kód kontaktu",
   "join_conversation": "Zapojte sa do konverzácie",
   "jump_in": "Jump In",

--- a/ui/src/translations/locales/sv.json
+++ b/ui/src/translations/locales/sv.json
@@ -31,6 +31,7 @@
   "first_name": "Förnamn, tack",
   "group_name": "Gruppens namn",
   "images": "{{count}} {{count; 1:image; default:images;}}",
+  "files": "{{count}} {{count; 1:fil; default:filer;}}",
   "invalid_contact_code": "Ogiltig kod",
   "join_conversation": "Gå med i konversationen",
   "jump_in": "Hoppa in",


### PR DESCRIPTION
### Summary
Resolves #505 

<img width="1709" height="543" alt="Screenshot 2025-12-14 at 5 36 01 PM" src="https://github.com/user-attachments/assets/4a52817c-9639-4f3c-9c8c-3e17e339c5dd" />

### TODO:
- [ ] CHANGELOG updated